### PR TITLE
Set a minimum size limit on the reconcile window

### DIFF
--- a/src/ReconcileWindow.cpp
+++ b/src/ReconcileWindow.cpp
@@ -42,7 +42,7 @@ private:
 
 ReconcileWindow::ReconcileWindow(const BRect frame, Account *account)
  : BWindow(frame,"",B_DOCUMENT_WINDOW_LOOK,B_NORMAL_WINDOW_FEEL,B_NOT_MINIMIZABLE |
-	B_NOT_ZOOMABLE)
+	B_NOT_ZOOMABLE | B_AUTO_UPDATE_SIZE_LIMITS)
 {
 	BString temp;
 	fCurrentDate = GetCurrentDate();


### PR DESCRIPTION
I've set a minimum size limit on the reconcile limit to be the same as the default height and width of the window and increased the default width to 650 as it seems to look better at least in my opinion.

Fixes #18 