### PR TITLE
Fix crashes in the Account Settings window and the Reports window

### DIFF
--- a/src/AccountSettingsWindow.cpp
+++ b/src/AccountSettingsWindow.cpp
@@ -113,16 +113,15 @@ void AccountSettingsWindow::MessageReceived(BMessage *msg)
 		}
 		case M_TOGGLE_USE_DEFAULT:
 		{
-			if(fUseDefault->Value()==B_CONTROL_ON)
-			{
+			bool useDefault = fUseDefault->Value() == B_CONTROL_ON;
+
+			if (useDefault)
 				fPrefView->Hide();
-				fAccount->UseDefaultLocale(true);
-			}
 			else
-			{
 				fPrefView->Show();
-				fAccount->UseDefaultLocale(false);
-			}
+
+			if (fAccount != NULL)
+				fAccount->UseDefaultLocale(useDefault);
 			
 			break;
 		}

--- a/src/BudgetReport.cpp
+++ b/src/BudgetReport.cpp
@@ -200,7 +200,6 @@ void ReportWindow::ComputeBudget(void)
 	float stringwidth = be_plain_font->StringWidth(stringitem->Text()) + 20;
 	if (maxwidths[0] < stringwidth)
 		maxwidths[0] = stringwidth;
-if (count > 1) debugger("");
 	
 	// This flag is for getting the next value from the row only when we don't
 	// already have a value


### PR DESCRIPTION
Fixes #4
The Account Settings window would crash if the account has not been
created yet and the checkbox (checked by default) was unchecked.

Fixes #25
The Reports window would crash if the Subtotal menu was set to anything
but the default None that would result in a multi-column output.