### PR TITLE
Issue #7: Memo bug

### DIFF
--- a/ToDO_Spanish
+++ b/ToDO_Spanish
@@ -9,10 +9,10 @@
 
 **Cadenas hardcodeadas:**
 ~~~~
-fUseDefault = new BCheckBox("usedefault","Use Default Currency Settings",
-DAlert *alert = new DAlert("Category is missing.","Do you want to add this transaction "
+- [X]fUseDefault = new BCheckBox("usedefault","Use Default Currency Settings",
+- [X] DAlert *alert = new DAlert("Category is missing.","Do you want to add this transaction "
 "without a category?","Add","Cancel",NULL,
-Uncategorized
+- [X] Uncategorized
 ~~~~
 - (SEGUIR COMPROBANDO)
 

--- a/locales/en.catkeys
+++ b/locales/en.catkeys
@@ -1,4 +1,4 @@
-1	English	application/x-vnd.wgp-CapitalBe	513412878
+1	English	application/x-vnd.wgp-CapitalBe	3199364022
 Year	ReportWindow		Year
 Edit transaction	TransactionEditWindow		Edit transaction
 None	ReportWindow		None
@@ -57,10 +57,12 @@ You need to have at least 2 accounts to perform a transfer.	MainWindow		You need
 Monthly	ScheduleListWindow		Monthly
 Category	BudgetWindow		Category
 Frequency	BudgetWindow		Frequency
+Category is missing.	CategoryBox		Category is missing.
 Subtotal	ReportWindow		Subtotal
 Memo:	ScheduleAddWindow		Memo:
 Uncategorized	SplitView		Uncategorized
 Frequency	ScheduleListWindow		Frequency
+Add	CategoryBox		Add
 Cancel	ReconcileWindow		Cancel
 Category	TransactionReport		Category
 Amount	ScheduleListWindow		Amount
@@ -82,8 +84,10 @@ Import	MainWindow		Import
 Interest earned	ReconcileWindow		Interest earned
 CapitalBe understands lots of different ways of entering dates. Apparently, this wasn't one of them. You'll need to change how you entered this date. Sorry.	ReportWindow		CapitalBe understands lots of different ways of entering dates. Apparently, this wasn't one of them. You'll need to change how you entered this date. Sorry.
 Could not import the data in the file %%FILENAME%%.	MainWindow		Could not import the data in the file %%FILENAME%%.
+Quit	Locale		Quit
 Once deleted, you will not be able to get back any data on this account.	MainWindow		Once deleted, you will not be able to get back any data on this account.
 Total deposits: %s	ReconcileWindow		Total deposits: %s
+Save bugreport	Locale		Save bugreport
 Amount	CheckView		Amount
 Indefinitely	ScheduleAddWindow		Indefinitely
 Cancel	MainWindow		Cancel
@@ -92,8 +96,8 @@ Appears before amount	PrefWindow		Appears before amount
 Unreconciled total: %s	ReconcileWindow		Unreconciled total: %s
 Date	TransactionReport		Date
 There may be a typo or the wrong kind of currency symbol for this account.	ReconcileWindow		There may be a typo or the wrong kind of currency symbol for this account.
-Really delete account?	MainWindow		Really delete account?
 Payee	CheckView		Payee
+Really delete account?	MainWindow		Really delete account?
 DEP	ReconcileWindow		DEP
 Income	BudgetWindow		Income
 This really shouldn't happen, so you probably should e-mail support about this.	MainWindow		This really shouldn't happen, so you probably should e-mail support about this.
@@ -161,8 +165,8 @@ Numbered transactions cannot be scheduled.	MainWindow		Numbered transactions can
 New…	MainWindow		New…
 English	ReconcileWindow	Path to localized helpfiles. Only translate if available in your language.	English
 Quick Balance failed. This doesn't mean that you did something wrong - it's just that Quick Balance works on simpler cases in balancing an account than this one. Sorry.	ReconcileWindow		Quick Balance failed. This doesn't mean that you did something wrong - it's just that Quick Balance works on simpler cases in balancing an account than this one. Sorry.
-Transfer	BudgetWindow		Transfer
 Amount: %s	ScheduleAddWindow		Amount: %s
+Transfer	BudgetWindow		Transfer
 Starting date:	ScheduleAddWindow		Starting date:
 Settings…	MainWindow		Settings…
 Monthly	Budget		Monthly
@@ -179,8 +183,8 @@ Amount	TransactionReport		Amount
 Transaction	MainWindow		Transaction
 Edit transfer	TransferWindow		Edit transfer
 Amount	TransferWindow		Amount
-Reports	MainWindow		Reports
 Categories	CategoryWindow		Categories
+Reports	MainWindow		Reports
 Date	CheckView		Date
 Account	MainWindow		Account
 Currency format: %s	PrefWindow		Currency format: %s
@@ -196,6 +200,7 @@ You can schedule transfers, deposits, or ATM transactions.	MainWindow		You can s
 Success!	ReconcileWindow		Success!
 Income	CategoryWindow		Income
 Edit category	CategoryWindow		Edit category
+Do you want to add this transaction without a category?	CategoryBox		Do you want to add this transaction without a category?
 QuickTracker	RegisterView		QuickTracker
 Schedule transaction	ScheduleAddWindow		Schedule transaction
 Type: %s	ScheduleAddWindow		Type: %s
@@ -222,17 +227,21 @@ Enter a transfer…	MainWindow		Enter a transfer…
 File	MainWindow		File
 Tools	MainWindow		Tools
 Transaction type is missing.	CheckNumBox		Transaction type is missing.
+Uncategorized	CategoryBox		Uncategorized
 Split	TransactionItem		Split
 CapitalBe didn't understand the amount for Interest Earned.	ReconcileWindow		CapitalBe didn't understand the amount for Interest Earned.
 Split	SplitView		Split
 The split total must match the amount box.	SplitView		The split total must match the amount box.
 Delete…	MainWindow		Delete…
+CapitalBe has run into a bug. This shouldn't happen, but it has.\nWould you like to:\n\n1) Save the bug to a text file for uploading to\nCapitalBe's issue tracker (https://github.com/HaikuArchives/CapitalBe/issues)\n\n2) Just quit and do nothing\n	Locale		CapitalBe has run into a bug. This shouldn't happen, but it has.\nWould you like to:\n\n1) Save the bug to a text file for uploading to\nCapitalBe's issue tracker (https://github.com/HaikuArchives/CapitalBe/issues)\n\n2) Just quit and do nothing\n
 Amount	BudgetWindow		Amount
+Cancel	CategoryBox		Cancel
 Scheduled transactions	ScheduleListWindow		Scheduled transactions
+Agh! Bug!	Locale		Agh! Bug!
 Starting date:	ReportWindow		Starting date:
 Starting balance	ReconcileWindow		Starting balance
-Amount	CashFlowReport		Amount
 Quarterly	ScheduleAddWindow		Quarterly
+Amount	CashFlowReport		Amount
 Hide Split	SplitView		Hide Split
 Reconcile:	ReconcileWindow		Reconcile:
 Total charges:	ReconcileWindow		Total charges:
@@ -259,9 +268,9 @@ English	ReportWindow	Path to localized helpfiles. Only translate if available in
 Quarterly	BudgetWindow		Quarterly
 Remove category	CategoryWindow		Remove category
 Decimal:	PrefWindow		Decimal:
+Split	ScheduleAddWindow		Split
 Month, Day, Year	PrefWindow		Month, Day, Year
 You need to enter the date for the statement to Quick Balance.	ReconcileWindow		You need to enter the date for the statement to Quick Balance.
-Split	ScheduleAddWindow		Split
 Use default currency settings	AccountSettingsWindow		Use default currency settings
 CapitalBe didn't understand the date you entered.	ReportWindow		CapitalBe didn't understand the date you entered.
 Unknown	ScheduleListWindow		Unknown

--- a/src/CategoryBox.cpp
+++ b/src/CategoryBox.cpp
@@ -3,6 +3,10 @@
 #include "Database.h"
 #include "MsgDefs.h"
 #include "TimeSupport.h"
+#include <Catalog.h>
+
+#undef B_TRANSLATION_CONTEXT
+#define B_TRANSLATION_CONTEXT "CategoryBox"
 
 CategoryBoxFilter::CategoryBoxFilter(CategoryBox* box) : AutoTextControlFilter(box) {}
 
@@ -71,13 +75,12 @@ bool
 CategoryBox::Validate(void)
 {
 	if (strlen(Text()) < 1) {
-		DAlert* alert = new DAlert("Category is missing.",
-			"Do you want to add this transaction "
-			"without a category?",
-			"Add", "Cancel", NULL, B_WIDTH_AS_USUAL, B_WARNING_ALERT);
+		DAlert* alert = new DAlert(B_TRANSLATE("Category is missing."),
+			B_TRANSLATE("Do you want to add this transaction without a category?"),
+			B_TRANSLATE("Add"), B_TRANSLATE("Cancel"), NULL, B_WIDTH_AS_USUAL, B_WARNING_ALERT);
 		int32 value = alert->Go();
 		if (value == 0)
-			SetText("Uncategorized");
+			SetText(B_TRANSLATE("Uncategorized"));
 		else
 			return false;
 	}

--- a/src/CategoryBox.cpp
+++ b/src/CategoryBox.cpp
@@ -8,6 +8,7 @@
 #undef B_TRANSLATION_CONTEXT
 #define B_TRANSLATION_CONTEXT "CategoryBox"
 
+
 CategoryBoxFilter::CategoryBoxFilter(CategoryBox* box) : AutoTextControlFilter(box) {}
 
 filter_result

--- a/src/CppSQLite3.cpp
+++ b/src/CppSQLite3.cpp
@@ -1,1435 +1,1365 @@
-/*
- * CppSQLite
- * Developed by Rob Groves <rob.groves@btinternet.com>
- * Maintained by NeoSmart Technologies <http://neosmart.net/>
- * See LICENSE file for copyright and license info
-*/
-
+////////////////////////////////////////////////////////////////////////////////
+// CppSQLite3 - A C++ wrapper around the SQLite3 embedded database library.
+//
+// Copyright (c) 2004..2007 Rob Groves. All Rights Reserved. rob.groves@btinternet.com
+//
+// Permission to use, copy, modify, and distribute this software and its
+// documentation for any purpose, without fee, and without a written
+// agreement, is hereby granted, provided that the above copyright notice,
+// this paragraph and the following two paragraphs appear in all copies,
+// modifications, and distributions.
+//
+// IN NO EVENT SHALL THE AUTHOR BE LIABLE TO ANY PARTY FOR DIRECT,
+// INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST
+// PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+// EVEN IF THE AUTHOR HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// THE AUTHOR SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+// PARTICULAR PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF
+// ANY, PROVIDED HEREUNDER IS PROVIDED "AS IS". THE AUTHOR HAS NO OBLIGATION
+// TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+//
+// V3.0		03/08/2004	-Initial Version for sqlite3
+//
+// V3.1		16/09/2004	-Implemented getXXXXField using sqlite3 functions
+//						-Added CppSQLiteDB3::tableExists()
+//
+// V3.2		01/07/2005	-Fixed execScalar to handle a NULL result
+//			12/07/2007	-Added int64 functions to CppSQLite3Query
+//						-Throw exception from CppSQLite3DB::close() if error
+//						-Trap above exception in CppSQLite3DB::~CppSQLite3DB()
+//						-Fix to CppSQLite3DB::compile() as provided by Dave Rollins.
+//						-sqlite3_prepare replaced with sqlite3_prepare_v2
+//						-Added Name based parameter binding to CppSQLite3Statement.
+////////////////////////////////////////////////////////////////////////////////
 #include "CppSQLite3.h"
 #include <cstdlib>
-#include <utility>
 
 
 // Named constant for passing to CppSQLite3Exception when passing it a string
 // that cannot be deleted.
-static const bool DONT_DELETE_MSG=false;
-
-// Error message used when throwing CppSQLite3Exception when allocations fail.
-static const char* const ALLOCATION_ERROR_MESSAGE = "Cannot allocate memory";
+static const bool DONT_DELETE_MSG = false;
 
 ////////////////////////////////////////////////////////////////////////////////
 // Prototypes for SQLite functions not included in SQLite DLL, but copied below
 // from SQLite encode.c
 ////////////////////////////////////////////////////////////////////////////////
-int sqlite3_encode_binary(const unsigned char *in, int n, unsigned char *out);
-int sqlite3_decode_binary(const unsigned char *in, unsigned char *out);
+int sqlite3_encode_binary(const unsigned char* in, int n, unsigned char* out);
+int sqlite3_decode_binary(const unsigned char* in, unsigned char* out);
 
 ////////////////////////////////////////////////////////////////////////////////
 
-namespace detail
-{
-
-SQLite3Memory::SQLite3Memory() :
-    mnBufferLen(0),
-    mpBuf(nullptr)
-{
-}
-
-SQLite3Memory::SQLite3Memory(int nBufferLen) :
-    mnBufferLen(nBufferLen),
-    mpBuf(sqlite3_malloc(nBufferLen))
-{
-    if (!mpBuf && mnBufferLen>0)
-    {
-        throw CppSQLite3Exception(CPPSQLITE_ERROR,
-                                ALLOCATION_ERROR_MESSAGE,
-                                DONT_DELETE_MSG);
-    }
-}
-
-SQLite3Memory::SQLite3Memory(const char* szFormat, va_list list) :
-    mnBufferLen(0),
-    mpBuf(sqlite3_vmprintf(szFormat, list))
-{
-    if (!mpBuf)
-    {
-        throw CppSQLite3Exception(CPPSQLITE_ERROR,
-                                ALLOCATION_ERROR_MESSAGE,
-                                DONT_DELETE_MSG);
-    }
-    mnBufferLen = std::strlen(static_cast<char const*>(mpBuf))+1;
-}
-
-SQLite3Memory::~SQLite3Memory()
-{
-    clear();
-}
-
-SQLite3Memory::SQLite3Memory(SQLite3Memory const& other) :
-    mnBufferLen(other.mnBufferLen),
-    mpBuf(sqlite3_malloc(other.mnBufferLen))
-{
-    if (!mpBuf && mnBufferLen>0)
-    {
-        throw CppSQLite3Exception(CPPSQLITE_ERROR,
-                                ALLOCATION_ERROR_MESSAGE,
-                                DONT_DELETE_MSG);
-    }
-    std::memcpy(mpBuf, other.mpBuf, mnBufferLen);
-}
-
-SQLite3Memory& SQLite3Memory::operator=(SQLite3Memory const& lhs)
-{
-    SQLite3Memory tmp(lhs);
-    swap(tmp);
-    return *this;
-}
-
-SQLite3Memory::SQLite3Memory(SQLite3Memory&& other) :
-    mnBufferLen(other.mnBufferLen),
-    mpBuf(other.mpBuf)
-{
-    other.mnBufferLen = 0;
-    other.mpBuf = nullptr;
-}
-
-SQLite3Memory& SQLite3Memory::operator=(SQLite3Memory&& lhs)
-{
-    swap(lhs);
-    return *this;
-}
-
-void SQLite3Memory::swap(SQLite3Memory& other)
-{
-    std::swap(mnBufferLen, other.mnBufferLen);
-    std::swap(mpBuf, other.mpBuf);
-}
-
-void SQLite3Memory::clear()
-{
-    sqlite3_free(mpBuf);
-    mpBuf = nullptr;
-    mnBufferLen = 0;
-}
-
-}
-
 ////////////////////////////////////////////////////////////////////////////////
 
-CppSQLite3Exception::CppSQLite3Exception(const int nErrCode,
-                                    const char* szErrMess,
-                                    bool bDeleteMsg/*=true*/) :
-                                    mnErrCode(nErrCode)
+CppSQLite3Exception::CppSQLite3Exception(
+	const int nErrCode, char* szErrMess, bool bDeleteMsg /*=true*/)
+	: mnErrCode(nErrCode)
 {
-    mpszErrMess = sqlite3_mprintf("%s[%d]: %s",
-                                errorCodeAsString(nErrCode),
-                                nErrCode,
-                                szErrMess ? szErrMess : "");
+	mpszErrMess = sqlite3_mprintf(
+		"%s[%d]: %s", errorCodeAsString(nErrCode), nErrCode, szErrMess ? szErrMess : "");
 
-    if (bDeleteMsg && szErrMess)
-    {
-        sqlite3_free((void*)szErrMess);
-    }
+	if (bDeleteMsg && szErrMess) {
+		sqlite3_free(szErrMess);
+	}
 }
 
 
-CppSQLite3Exception::CppSQLite3Exception(const CppSQLite3Exception&  e) :
-                                    mnErrCode(e.mnErrCode)
+CppSQLite3Exception::CppSQLite3Exception(const CppSQLite3Exception& e) : mnErrCode(e.mnErrCode)
 {
-    mpszErrMess = 0;
-    if (e.mpszErrMess)
-    {
-        mpszErrMess = sqlite3_mprintf("%s", e.mpszErrMess);
-    }
+	mpszErrMess = 0;
+	if (e.mpszErrMess) {
+		mpszErrMess = sqlite3_mprintf("%s", e.mpszErrMess);
+	}
 }
 
 
-const char* CppSQLite3Exception::errorCodeAsString(int nErrCode)
+const char*
+CppSQLite3Exception::errorCodeAsString(int nErrCode)
 {
-    switch (nErrCode)
-    {
-        case SQLITE_OK          : return "SQLITE_OK";
-        case SQLITE_ERROR       : return "SQLITE_ERROR";
-        case SQLITE_INTERNAL    : return "SQLITE_INTERNAL";
-        case SQLITE_PERM        : return "SQLITE_PERM";
-        case SQLITE_ABORT       : return "SQLITE_ABORT";
-        case SQLITE_BUSY        : return "SQLITE_BUSY";
-        case SQLITE_LOCKED      : return "SQLITE_LOCKED";
-        case SQLITE_NOMEM       : return "SQLITE_NOMEM";
-        case SQLITE_READONLY    : return "SQLITE_READONLY";
-        case SQLITE_INTERRUPT   : return "SQLITE_INTERRUPT";
-        case SQLITE_IOERR       : return "SQLITE_IOERR";
-        case SQLITE_CORRUPT     : return "SQLITE_CORRUPT";
-        case SQLITE_NOTFOUND    : return "SQLITE_NOTFOUND";
-        case SQLITE_FULL        : return "SQLITE_FULL";
-        case SQLITE_CANTOPEN    : return "SQLITE_CANTOPEN";
-        case SQLITE_PROTOCOL    : return "SQLITE_PROTOCOL";
-        case SQLITE_EMPTY       : return "SQLITE_EMPTY";
-        case SQLITE_SCHEMA      : return "SQLITE_SCHEMA";
-        case SQLITE_TOOBIG      : return "SQLITE_TOOBIG";
-        case SQLITE_CONSTRAINT  : return "SQLITE_CONSTRAINT";
-        case SQLITE_MISMATCH    : return "SQLITE_MISMATCH";
-        case SQLITE_MISUSE      : return "SQLITE_MISUSE";
-        case SQLITE_NOLFS       : return "SQLITE_NOLFS";
-        case SQLITE_AUTH        : return "SQLITE_AUTH";
-        case SQLITE_FORMAT      : return "SQLITE_FORMAT";
-        case SQLITE_RANGE       : return "SQLITE_RANGE";
-        case SQLITE_ROW         : return "SQLITE_ROW";
-        case SQLITE_DONE        : return "SQLITE_DONE";
-        case CPPSQLITE_ERROR    : return "CPPSQLITE_ERROR";
-        default: return "UNKNOWN_ERROR";
-    }
+	switch (nErrCode) {
+		case SQLITE_OK:
+			return "SQLITE_OK";
+		case SQLITE_ERROR:
+			return "SQLITE_ERROR";
+		case SQLITE_INTERNAL:
+			return "SQLITE_INTERNAL";
+		case SQLITE_PERM:
+			return "SQLITE_PERM";
+		case SQLITE_ABORT:
+			return "SQLITE_ABORT";
+		case SQLITE_BUSY:
+			return "SQLITE_BUSY";
+		case SQLITE_LOCKED:
+			return "SQLITE_LOCKED";
+		case SQLITE_NOMEM:
+			return "SQLITE_NOMEM";
+		case SQLITE_READONLY:
+			return "SQLITE_READONLY";
+		case SQLITE_INTERRUPT:
+			return "SQLITE_INTERRUPT";
+		case SQLITE_IOERR:
+			return "SQLITE_IOERR";
+		case SQLITE_CORRUPT:
+			return "SQLITE_CORRUPT";
+		case SQLITE_NOTFOUND:
+			return "SQLITE_NOTFOUND";
+		case SQLITE_FULL:
+			return "SQLITE_FULL";
+		case SQLITE_CANTOPEN:
+			return "SQLITE_CANTOPEN";
+		case SQLITE_PROTOCOL:
+			return "SQLITE_PROTOCOL";
+		case SQLITE_EMPTY:
+			return "SQLITE_EMPTY";
+		case SQLITE_SCHEMA:
+			return "SQLITE_SCHEMA";
+		case SQLITE_TOOBIG:
+			return "SQLITE_TOOBIG";
+		case SQLITE_CONSTRAINT:
+			return "SQLITE_CONSTRAINT";
+		case SQLITE_MISMATCH:
+			return "SQLITE_MISMATCH";
+		case SQLITE_MISUSE:
+			return "SQLITE_MISUSE";
+		case SQLITE_NOLFS:
+			return "SQLITE_NOLFS";
+		case SQLITE_AUTH:
+			return "SQLITE_AUTH";
+		case SQLITE_FORMAT:
+			return "SQLITE_FORMAT";
+		case SQLITE_RANGE:
+			return "SQLITE_RANGE";
+		case SQLITE_ROW:
+			return "SQLITE_ROW";
+		case SQLITE_DONE:
+			return "SQLITE_DONE";
+		case CPPSQLITE_ERROR:
+			return "CPPSQLITE_ERROR";
+		default:
+			return "UNKNOWN_ERROR";
+	}
 }
-
 
 CppSQLite3Exception::~CppSQLite3Exception()
 {
-    if (mpszErrMess)
-    {
-        sqlite3_free(mpszErrMess);
-        mpszErrMess = 0;
-    }
+	if (mpszErrMess) {
+		sqlite3_free(mpszErrMess);
+		mpszErrMess = 0;
+	}
 }
-
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void CppSQLite3Buffer::clear()
+CppSQLite3Buffer::CppSQLite3Buffer()
 {
-    mBuf.clear();
+	mpBuf = 0;
+}
+
+CppSQLite3Buffer::~CppSQLite3Buffer()
+{
+	clear();
 }
 
 
-const char* CppSQLite3Buffer::format(const char* szFormat, ...)
+void
+CppSQLite3Buffer::clear()
 {
-    va_list va;
-    detail::SQLite3Memory tmpBuf;
-    try
-    {
-        va_start(va, szFormat);
-        tmpBuf = detail::SQLite3Memory(szFormat, va);
-        va_end(va);
-    }
-    catch(CppSQLite3Exception&)
-    {
-        va_end(va);
-        throw;
-    }
-    mBuf = std::move(tmpBuf);
-    return static_cast<const char*>(mBuf.getBuffer());
+	if (mpBuf) {
+		sqlite3_free(mpBuf);
+		mpBuf = 0;
+	}
 }
 
+
+const char*
+CppSQLite3Buffer::format(const char* szFormat, ...)
+{
+	clear();
+	va_list va;
+	va_start(va, szFormat);
+	mpBuf = sqlite3_vmprintf(szFormat, va);
+	va_end(va);
+	return mpBuf;
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 
-CppSQLite3Binary::CppSQLite3Binary() :
-                        mpBuf(0),
-                        mnBinaryLen(0),
-                        mnBufferLen(0),
-                        mnEncodedLen(0),
-                        mbEncoded(false)
+CppSQLite3Binary::CppSQLite3Binary()
+	: mpBuf(0), mnBinaryLen(0), mnBufferLen(0), mnEncodedLen(0), mbEncoded(false)
 {
 }
-
 
 CppSQLite3Binary::~CppSQLite3Binary()
 {
-    clear();
+	clear();
 }
 
 
-void CppSQLite3Binary::setBinary(const unsigned char* pBuf, int nLen)
+void
+CppSQLite3Binary::setBinary(const unsigned char* pBuf, int nLen)
 {
-    mpBuf = allocBuffer(nLen);
-    memcpy(mpBuf, pBuf, nLen);
+	mpBuf = allocBuffer(nLen);
+	memcpy(mpBuf, pBuf, nLen);
 }
 
 
-void CppSQLite3Binary::setEncoded(const unsigned char* pBuf)
+void
+CppSQLite3Binary::setEncoded(const unsigned char* pBuf)
 {
-    clear();
+	clear();
 
-    mnEncodedLen = strlen((const char*)pBuf);
-    mnBufferLen = mnEncodedLen + 1; // Allow for NULL terminator
+	mnEncodedLen = strlen((const char*)pBuf);
+	mnBufferLen = mnEncodedLen + 1;	 // Allow for NULL terminator
 
-    mpBuf = (unsigned char*)malloc(mnBufferLen);
+	mpBuf = (unsigned char*)malloc(mnBufferLen);
 
-    if (!mpBuf)
-    {
-        throw CppSQLite3Exception(CPPSQLITE_ERROR,
-                                ALLOCATION_ERROR_MESSAGE,
-                                DONT_DELETE_MSG);
-    }
+	if (!mpBuf) {
+		throw CppSQLite3Exception(CPPSQLITE_ERROR, "Cannot allocate memory", DONT_DELETE_MSG);
+	}
 
-    memcpy(mpBuf, pBuf, mnBufferLen);
-    mbEncoded = true;
+	memcpy(mpBuf, pBuf, mnBufferLen);
+	mbEncoded = true;
 }
 
 
-const unsigned char* CppSQLite3Binary::getEncoded()
+const unsigned char*
+CppSQLite3Binary::getEncoded()
 {
-    if (!mbEncoded)
-    {
-        unsigned char* ptmp = (unsigned char*)malloc(mnBinaryLen);
-        memcpy(ptmp, mpBuf, mnBinaryLen);
-        mnEncodedLen = sqlite3_encode_binary(ptmp, mnBinaryLen, mpBuf);
-        free(ptmp);
-        mbEncoded = true;
-    }
+	if (!mbEncoded) {
+		unsigned char* ptmp = (unsigned char*)malloc(mnBinaryLen);
+		memcpy(ptmp, mpBuf, mnBinaryLen);
+		mnEncodedLen = sqlite3_encode_binary(ptmp, mnBinaryLen, mpBuf);
+		free(ptmp);
+		mbEncoded = true;
+	}
 
-    return mpBuf;
+	return mpBuf;
 }
 
 
-const unsigned char* CppSQLite3Binary::getBinary()
+const unsigned char*
+CppSQLite3Binary::getBinary()
 {
-    if (mbEncoded)
-    {
-        // in/out buffers can be the same
-        mnBinaryLen = sqlite3_decode_binary(mpBuf, mpBuf);
+	if (mbEncoded) {
+		// in/out buffers can be the same
+		mnBinaryLen = sqlite3_decode_binary(mpBuf, mpBuf);
 
-        if (mnBinaryLen == -1)
-        {
-            throw CppSQLite3Exception(CPPSQLITE_ERROR,
-                                    "Cannot decode binary",
-                                    DONT_DELETE_MSG);
-        }
+		if (mnBinaryLen == -1) {
+			throw CppSQLite3Exception(CPPSQLITE_ERROR, "Cannot decode binary", DONT_DELETE_MSG);
+		}
 
-        mbEncoded = false;
-    }
+		mbEncoded = false;
+	}
 
-    return mpBuf;
+	return mpBuf;
 }
 
 
-int CppSQLite3Binary::getBinaryLength()
+int
+CppSQLite3Binary::getBinaryLength()
 {
-    getBinary();
-    return mnBinaryLen;
+	getBinary();
+	return mnBinaryLen;
 }
 
 
-unsigned char* CppSQLite3Binary::allocBuffer(int nLen)
+unsigned char*
+CppSQLite3Binary::allocBuffer(int nLen)
 {
-    clear();
+	clear();
 
-    // Allow extra space for encoded binary as per comments in
-    // SQLite encode.c See bottom of this file for implementation
-    // of SQLite functions use 3 instead of 2 just to be sure ;-)
-    mnBinaryLen = nLen;
-    mnBufferLen = 3 + (257*nLen)/254;
+	// Allow extra space for encoded binary as per comments in
+	// SQLite encode.c See bottom of this file for implementation
+	// of SQLite functions use 3 instead of 2 just to be sure ;-)
+	mnBinaryLen = nLen;
+	mnBufferLen = 3 + (257 * nLen) / 254;
 
-    mpBuf = (unsigned char*)malloc(mnBufferLen);
+	mpBuf = (unsigned char*)malloc(mnBufferLen);
 
-    if (!mpBuf)
-    {
-        throw CppSQLite3Exception(CPPSQLITE_ERROR,
-                                ALLOCATION_ERROR_MESSAGE,
-                                DONT_DELETE_MSG);
-    }
+	if (!mpBuf) {
+		throw CppSQLite3Exception(CPPSQLITE_ERROR, "Cannot allocate memory", DONT_DELETE_MSG);
+	}
 
-    mbEncoded = false;
+	mbEncoded = false;
 
-    return mpBuf;
+	return mpBuf;
 }
 
 
-void CppSQLite3Binary::clear()
+void
+CppSQLite3Binary::clear()
 {
-    if (mpBuf)
-    {
-        mnBinaryLen = 0;
-        mnBufferLen = 0;
-        free(mpBuf);
-        mpBuf = 0;
-    }
+	if (mpBuf) {
+		mnBinaryLen = 0;
+		mnBufferLen = 0;
+		free(mpBuf);
+		mpBuf = 0;
+	}
 }
-
 
 ////////////////////////////////////////////////////////////////////////////////
 
 CppSQLite3Query::CppSQLite3Query()
 {
-    mpVM = 0;
-    mbEof = true;
-    mnCols = 0;
-    mbOwnVM = false;
+	mpVM = 0;
+	mbEof = true;
+	mnCols = 0;
+	mbOwnVM = false;
 }
-
 
 CppSQLite3Query::CppSQLite3Query(const CppSQLite3Query& rQuery)
 {
-    mpVM = rQuery.mpVM;
-    // Only one object can own the VM
-    const_cast<CppSQLite3Query&>(rQuery).mpVM = 0;
-    mbEof = rQuery.mbEof;
-    mnCols = rQuery.mnCols;
-    mbOwnVM = rQuery.mbOwnVM;
+	mpVM = rQuery.mpVM;
+	// Only one object can own the VM
+	const_cast<CppSQLite3Query&>(rQuery).mpVM = 0;
+	mbEof = rQuery.mbEof;
+	mnCols = rQuery.mnCols;
+	mbOwnVM = rQuery.mbOwnVM;
 }
 
 
-CppSQLite3Query::CppSQLite3Query(sqlite3* pDB,
-                            sqlite3_stmt* pVM,
-                            bool bEof,
-                            bool bOwnVM/*=true*/)
+CppSQLite3Query::CppSQLite3Query(sqlite3* pDB, sqlite3_stmt* pVM, bool bEof, bool bOwnVM /*=true*/)
 {
-    mpDB = pDB;
-    mpVM = pVM;
-    mbEof = bEof;
-    mnCols = sqlite3_column_count(mpVM);
-    mbOwnVM = bOwnVM;
+	mpDB = pDB;
+	mpVM = pVM;
+	mbEof = bEof;
+	mnCols = sqlite3_column_count(mpVM);
+	mbOwnVM = bOwnVM;
 }
-
 
 CppSQLite3Query::~CppSQLite3Query()
 {
-    try
-    {
-        finalize();
-    }
-    catch (...)
-    {
-    }
+	try {
+		finalize();
+	} catch (...) {
+	}
 }
 
 
-CppSQLite3Query& CppSQLite3Query::operator=(const CppSQLite3Query& rQuery)
+CppSQLite3Query&
+CppSQLite3Query::operator=(const CppSQLite3Query& rQuery)
 {
-    try
-    {
-        finalize();
-    }
-    catch (...)
-    {
-    }
-    mpVM = rQuery.mpVM;
-    // Only one object can own the VM
-    const_cast<CppSQLite3Query&>(rQuery).mpVM = 0;
-    mbEof = rQuery.mbEof;
-    mnCols = rQuery.mnCols;
-    mbOwnVM = rQuery.mbOwnVM;
-    return *this;
+	try {
+		finalize();
+	} catch (...) {
+	}
+	mpVM = rQuery.mpVM;
+	// Only one object can own the VM
+	const_cast<CppSQLite3Query&>(rQuery).mpVM = 0;
+	mbEof = rQuery.mbEof;
+	mnCols = rQuery.mnCols;
+	mbOwnVM = rQuery.mbOwnVM;
+	return *this;
 }
 
 
-int CppSQLite3Query::numFields() const
+int
+CppSQLite3Query::numFields()
 {
-    checkVM();
-    return mnCols;
+	checkVM();
+	return mnCols;
 }
 
 
-const char* CppSQLite3Query::fieldValue(int nField) const
+const char*
+CppSQLite3Query::fieldValue(int nField)
 {
-    checkVM();
+	checkVM();
 
-    if (nField < 0 || nField > mnCols-1)
-    {
-        throw CppSQLite3Exception(CPPSQLITE_ERROR,
-                                "Invalid field index requested",
-                                DONT_DELETE_MSG);
-    }
+	if (nField < 0 || nField > mnCols - 1) {
+		throw CppSQLite3Exception(
+			CPPSQLITE_ERROR, "Invalid field index requested", DONT_DELETE_MSG);
+	}
 
-    return (const char*)sqlite3_column_text(mpVM, nField);
+	return (const char*)sqlite3_column_text(mpVM, nField);
 }
 
 
-const char* CppSQLite3Query::fieldValue(const char* szField) const
+const char*
+CppSQLite3Query::fieldValue(const char* szField)
 {
-    int nField = fieldIndex(szField);
-    return (const char*)sqlite3_column_text(mpVM, nField);
+	int nField = fieldIndex(szField);
+	return (const char*)sqlite3_column_text(mpVM, nField);
 }
 
 
-int CppSQLite3Query::getIntField(int nField, int nNullValue/*=0*/) const
+int
+CppSQLite3Query::getIntField(int nField, int nNullValue /*=0*/)
 {
-    if (fieldDataType(nField) == SQLITE_NULL)
-    {
-        return nNullValue;
-    }
-    else
-    {
-        return sqlite3_column_int(mpVM, nField);
-    }
+	if (fieldDataType(nField) == SQLITE_NULL) {
+		return nNullValue;
+	} else {
+		return sqlite3_column_int(mpVM, nField);
+	}
 }
 
 
-int CppSQLite3Query::getIntField(const char* szField, int nNullValue/*=0*/) const
+int
+CppSQLite3Query::getIntField(const char* szField, int nNullValue /*=0*/)
 {
-    int nField = fieldIndex(szField);
-    return getIntField(nField, nNullValue);
+	int nField = fieldIndex(szField);
+	return getIntField(nField, nNullValue);
 }
 
 
-long long CppSQLite3Query::getInt64Field(int nField, long long nNullValue/*=0*/) const
+sqlite_int64
+CppSQLite3Query::getInt64Field(int nField, sqlite_int64 nNullValue /*=0*/)
 {
-    if (fieldDataType(nField) == SQLITE_NULL)
-    {
-        return nNullValue;
-    }
-    else
-    {
-        return sqlite3_column_int64(mpVM, nField);
-    }
+	if (fieldDataType(nField) == SQLITE_NULL) {
+		return nNullValue;
+	} else {
+		return sqlite3_column_int64(mpVM, nField);
+	}
 }
 
 
-long long CppSQLite3Query::getInt64Field(const char* szField, long long nNullValue/*=0*/) const
+sqlite_int64
+CppSQLite3Query::getInt64Field(const char* szField, sqlite_int64 nNullValue /*=0*/)
 {
-    int nField = fieldIndex(szField);
-    return getInt64Field(nField, nNullValue);
+	int nField = fieldIndex(szField);
+	return getInt64Field(nField, nNullValue);
 }
 
 
-float CppSQLite3Query::getFloatField(int nField, float fNullValue/*=0.0f*/) const
+double
+CppSQLite3Query::getFloatField(int nField, double fNullValue /*=0.0*/)
 {
-    if (fieldDataType(nField) == SQLITE_NULL)
-    {
-        return fNullValue;
-    }
-    else
-    {
-        return static_cast<float>(sqlite3_column_double(mpVM, nField));
-    }
+	if (fieldDataType(nField) == SQLITE_NULL) {
+		return fNullValue;
+	} else {
+		return sqlite3_column_double(mpVM, nField);
+	}
 }
 
 
-float CppSQLite3Query::getFloatField(const char* szField, float fNullValue/*=0.0f*/) const
+
+double
+CppSQLite3Query::getFloatField(const char* szField, double fNullValue /*=0.0*/)
 {
-    int nField = fieldIndex(szField);
-    return getFloatField(nField, fNullValue);
+	int nField = fieldIndex(szField);
+	return getFloatField(nField, fNullValue);
 }
 
 
-double CppSQLite3Query::getDoubleField(int nField, double dNullValue/*=0.0*/) const
+
+const char*
+CppSQLite3Query::getStringField(int nField, const char* szNullValue /*=""*/)
 {
-    if (fieldDataType(nField) == SQLITE_NULL)
-    {
-        return dNullValue;
-    }
-    else
-    {
-        return sqlite3_column_double(mpVM, nField);
-    }
+	if (fieldDataType(nField) == SQLITE_NULL) {
+		return szNullValue;
+	} else {
+		return (const char*)sqlite3_column_text(mpVM, nField);
+	}
 }
 
 
-double CppSQLite3Query::getDoubleField(const char* szField, double dNullValue/*=0.0*/) const
+
+const char*
+CppSQLite3Query::getStringField(const char* szField, const char* szNullValue /*=""*/)
 {
-    int nField = fieldIndex(szField);
-    return getDoubleField(nField, dNullValue);
+	int nField = fieldIndex(szField);
+	return getStringField(nField, szNullValue);
 }
 
 
-const char* CppSQLite3Query::getStringField(int nField, const char* szNullValue/*=""*/) const
+
+const unsigned char*
+CppSQLite3Query::getBlobField(int nField, int& nLen)
 {
-    if (fieldDataType(nField) == SQLITE_NULL)
-    {
-        return szNullValue;
-    }
-    else
-    {
-        return (const char*)sqlite3_column_text(mpVM, nField);
-    }
+	checkVM();
+
+	if (nField < 0 || nField > mnCols - 1) {
+		throw CppSQLite3Exception(
+			CPPSQLITE_ERROR, "Invalid field index requested", DONT_DELETE_MSG);
+	}
+
+	nLen = sqlite3_column_bytes(mpVM, nField);
+	return (const unsigned char*)sqlite3_column_blob(mpVM, nField);
 }
 
 
-const char* CppSQLite3Query::getStringField(const char* szField, const char* szNullValue/*=""*/) const
+
+const unsigned char*
+CppSQLite3Query::getBlobField(const char* szField, int& nLen)
 {
-    int nField = fieldIndex(szField);
-    return getStringField(nField, szNullValue);
+	int nField = fieldIndex(szField);
+	return getBlobField(nField, nLen);
 }
 
 
-const unsigned char* CppSQLite3Query::getBlobField(int nField, int& nLen) const
+
+bool
+CppSQLite3Query::fieldIsNull(int nField)
 {
-    checkVM();
-
-    if (nField < 0 || nField > mnCols-1)
-    {
-        throw CppSQLite3Exception(CPPSQLITE_ERROR,
-                                "Invalid field index requested",
-                                DONT_DELETE_MSG);
-    }
-
-    nLen = sqlite3_column_bytes(mpVM, nField);
-    return (const unsigned char*)sqlite3_column_blob(mpVM, nField);
+	return (fieldDataType(nField) == SQLITE_NULL);
 }
 
 
-const unsigned char* CppSQLite3Query::getBlobField(const char* szField, int& nLen) const
+
+bool
+CppSQLite3Query::fieldIsNull(const char* szField)
 {
-    int nField = fieldIndex(szField);
-    return getBlobField(nField, nLen);
+	int nField = fieldIndex(szField);
+	return (fieldDataType(nField) == SQLITE_NULL);
 }
 
 
-bool CppSQLite3Query::fieldIsNull(int nField) const
+
+int
+CppSQLite3Query::fieldIndex(const char* szField)
 {
-    return (fieldDataType(nField) == SQLITE_NULL);
+	checkVM();
+
+	if (szField) {
+		for (int nField = 0; nField < mnCols; nField++) {
+			const char* szTemp = sqlite3_column_name(mpVM, nField);
+
+			if (strcmp(szField, szTemp) == 0) {
+				return nField;
+			}
+		}
+	}
+
+	throw CppSQLite3Exception(CPPSQLITE_ERROR, "Invalid field name requested", DONT_DELETE_MSG);
 }
 
 
-bool CppSQLite3Query::fieldIsNull(const char* szField) const
+
+const char*
+CppSQLite3Query::fieldName(int nCol)
 {
-    int nField = fieldIndex(szField);
-    return (fieldDataType(nField) == SQLITE_NULL);
+	checkVM();
+
+	if (nCol < 0 || nCol > mnCols - 1) {
+		throw CppSQLite3Exception(
+			CPPSQLITE_ERROR, "Invalid field index requested", DONT_DELETE_MSG);
+	}
+
+	return sqlite3_column_name(mpVM, nCol);
 }
 
 
-int CppSQLite3Query::fieldIndex(const char* szField) const
+
+const char*
+CppSQLite3Query::fieldDeclType(int nCol)
 {
-    checkVM();
+	checkVM();
 
-    if (szField)
-    {
-        for (int nField = 0; nField < mnCols; nField++)
-        {
-            const char* szTemp = sqlite3_column_name(mpVM, nField);
+	if (nCol < 0 || nCol > mnCols - 1) {
+		throw CppSQLite3Exception(
+			CPPSQLITE_ERROR, "Invalid field index requested", DONT_DELETE_MSG);
+	}
 
-            if (strcmp(szField, szTemp) == 0)
-            {
-                return nField;
-            }
-        }
-    }
-
-    throw CppSQLite3Exception(CPPSQLITE_ERROR,
-                            "Invalid field name requested",
-                            DONT_DELETE_MSG);
+	return sqlite3_column_decltype(mpVM, nCol);
 }
 
 
-const char* CppSQLite3Query::fieldName(int nCol) const
+
+int
+CppSQLite3Query::fieldDataType(int nCol)
 {
-    checkVM();
+	checkVM();
 
-    if (nCol < 0 || nCol > mnCols-1)
-    {
-        throw CppSQLite3Exception(CPPSQLITE_ERROR,
-                                "Invalid field index requested",
-                                DONT_DELETE_MSG);
-    }
+	if (nCol < 0 || nCol > mnCols - 1) {
+		throw CppSQLite3Exception(
+			CPPSQLITE_ERROR, "Invalid field index requested", DONT_DELETE_MSG);
+	}
 
-    return sqlite3_column_name(mpVM, nCol);
+	return sqlite3_column_type(mpVM, nCol);
 }
 
 
-const char* CppSQLite3Query::fieldDeclType(int nCol) const
+
+bool
+CppSQLite3Query::eof()
 {
-    checkVM();
-
-    if (nCol < 0 || nCol > mnCols-1)
-    {
-        throw CppSQLite3Exception(CPPSQLITE_ERROR,
-                                "Invalid field index requested",
-                                DONT_DELETE_MSG);
-    }
-
-    return sqlite3_column_decltype(mpVM, nCol);
+	checkVM();
+	return mbEof;
 }
 
 
-int CppSQLite3Query::fieldDataType(int nCol) const
+
+void
+CppSQLite3Query::nextRow()
 {
-    checkVM();
+	checkVM();
 
-    if (nCol < 0 || nCol > mnCols-1)
-    {
-        throw CppSQLite3Exception(CPPSQLITE_ERROR,
-                                "Invalid field index requested",
-                                DONT_DELETE_MSG);
-    }
+	int nRet = sqlite3_step(mpVM);
 
-    return sqlite3_column_type(mpVM, nCol);
+	if (nRet == SQLITE_DONE) {
+		// no rows
+		mbEof = true;
+	} else if (nRet == SQLITE_ROW) {
+		// more rows, nothing to do
+	} else {
+		nRet = sqlite3_finalize(mpVM);
+		mpVM = 0;
+		const char* szError = sqlite3_errmsg(mpDB);
+		throw CppSQLite3Exception(nRet, (char*)szError, DONT_DELETE_MSG);
+	}
 }
 
 
-bool CppSQLite3Query::eof() const
+
+void
+CppSQLite3Query::finalize()
 {
-    checkVM();
-    return mbEof;
+	if (mpVM && mbOwnVM) {
+		int nRet = sqlite3_finalize(mpVM);
+		mpVM = 0;
+		if (nRet != SQLITE_OK) {
+			const char* szError = sqlite3_errmsg(mpDB);
+			throw CppSQLite3Exception(nRet, (char*)szError, DONT_DELETE_MSG);
+		}
+	}
 }
 
 
-void CppSQLite3Query::nextRow()
+
+void
+CppSQLite3Query::checkVM()
 {
-    checkVM();
-
-    int nRet = sqlite3_step(mpVM);
-
-    if (nRet == SQLITE_DONE)
-    {
-        // no rows
-        mbEof = true;
-    }
-    else if (nRet == SQLITE_ROW)
-    {
-        // more rows, nothing to do
-    }
-    else
-    {
-        nRet = sqlite3_finalize(mpVM);
-        mpVM = 0;
-        const char* szError = sqlite3_errmsg(mpDB);
-        throw CppSQLite3Exception(nRet,
-                                (char*)szError,
-                                DONT_DELETE_MSG);
-    }
+	if (mpVM == 0) {
+		throw CppSQLite3Exception(CPPSQLITE_ERROR, "Null Virtual Machine pointer", DONT_DELETE_MSG);
+	}
 }
-
-
-void CppSQLite3Query::finalize()
-{
-    if (mpVM && mbOwnVM)
-    {
-        int nRet = sqlite3_finalize(mpVM);
-        mpVM = 0;
-        if (nRet != SQLITE_OK)
-        {
-            const char* szError = sqlite3_errmsg(mpDB);
-            throw CppSQLite3Exception(nRet, (char*)szError, DONT_DELETE_MSG);
-        }
-    }
-}
-
-
-void CppSQLite3Query::checkVM() const
-{
-    if (mpVM == 0)
-    {
-        throw CppSQLite3Exception(CPPSQLITE_ERROR,
-                                "Null Virtual Machine pointer",
-                                DONT_DELETE_MSG);
-    }
-}
-
 
 ////////////////////////////////////////////////////////////////////////////////
 
 CppSQLite3Table::CppSQLite3Table()
 {
-    mpaszResults = 0;
-    mnRows = 0;
-    mnCols = 0;
-    mnCurrentRow = 0;
+	mpaszResults = 0;
+	mnRows = 0;
+	mnCols = 0;
+	mnCurrentRow = 0;
 }
-
 
 CppSQLite3Table::CppSQLite3Table(const CppSQLite3Table& rTable)
 {
-    mpaszResults = rTable.mpaszResults;
-    // Only one object can own the results
-    const_cast<CppSQLite3Table&>(rTable).mpaszResults = 0;
-    mnRows = rTable.mnRows;
-    mnCols = rTable.mnCols;
-    mnCurrentRow = rTable.mnCurrentRow;
+	mpaszResults = rTable.mpaszResults;
+	// Only one object can own the results
+	const_cast<CppSQLite3Table&>(rTable).mpaszResults = 0;
+	mnRows = rTable.mnRows;
+	mnCols = rTable.mnCols;
+	mnCurrentRow = rTable.mnCurrentRow;
 }
-
 
 CppSQLite3Table::CppSQLite3Table(char** paszResults, int nRows, int nCols)
 {
-    mpaszResults = paszResults;
-    mnRows = nRows;
-    mnCols = nCols;
-    mnCurrentRow = 0;
+	mpaszResults = paszResults;
+	mnRows = nRows;
+	mnCols = nCols;
+	mnCurrentRow = 0;
 }
-
 
 CppSQLite3Table::~CppSQLite3Table()
 {
-    try
-    {
-        finalize();
-    }
-    catch (...)
-    {
-    }
+	try {
+		finalize();
+	} catch (...) {
+	}
 }
 
 
-CppSQLite3Table& CppSQLite3Table::operator=(const CppSQLite3Table& rTable)
+
+CppSQLite3Table&
+CppSQLite3Table::operator=(const CppSQLite3Table& rTable)
 {
-    try
-    {
-        finalize();
-    }
-    catch (...)
-    {
-    }
-    mpaszResults = rTable.mpaszResults;
-    // Only one object can own the results
-    const_cast<CppSQLite3Table&>(rTable).mpaszResults = 0;
-    mnRows = rTable.mnRows;
-    mnCols = rTable.mnCols;
-    mnCurrentRow = rTable.mnCurrentRow;
-    return *this;
+	try {
+		finalize();
+	} catch (...) {
+	}
+	mpaszResults = rTable.mpaszResults;
+	// Only one object can own the results
+	const_cast<CppSQLite3Table&>(rTable).mpaszResults = 0;
+	mnRows = rTable.mnRows;
+	mnCols = rTable.mnCols;
+	mnCurrentRow = rTable.mnCurrentRow;
+	return *this;
 }
 
 
-void CppSQLite3Table::finalize()
+
+void
+CppSQLite3Table::finalize()
 {
-    if (mpaszResults)
-    {
-        sqlite3_free_table(mpaszResults);
-        mpaszResults = 0;
-    }
+	if (mpaszResults) {
+		sqlite3_free_table(mpaszResults);
+		mpaszResults = 0;
+	}
 }
 
 
-int CppSQLite3Table::numFields() const
+
+int
+CppSQLite3Table::numFields()
 {
-    checkResults();
-    return mnCols;
+	checkResults();
+	return mnCols;
 }
 
 
-int CppSQLite3Table::numRows() const
+
+int
+CppSQLite3Table::numRows()
 {
-    checkResults();
-    return mnRows;
+	checkResults();
+	return mnRows;
 }
 
 
-const char* CppSQLite3Table::fieldValue(int nField) const
+
+const char*
+CppSQLite3Table::fieldValue(int nField)
 {
-    checkResults();
+	checkResults();
 
-    if (nField < 0 || nField > mnCols-1)
-    {
-        throw CppSQLite3Exception(CPPSQLITE_ERROR,
-                                "Invalid field index requested",
-                                DONT_DELETE_MSG);
-    }
+	if (nField < 0 || nField > mnCols - 1) {
+		throw CppSQLite3Exception(
+			CPPSQLITE_ERROR, "Invalid field index requested", DONT_DELETE_MSG);
+	}
 
-    int nIndex = (mnCurrentRow*mnCols) + mnCols + nField;
-    return mpaszResults[nIndex];
+	int nIndex = (mnCurrentRow * mnCols) + mnCols + nField;
+	return mpaszResults[nIndex];
 }
 
 
-const char* CppSQLite3Table::fieldValue(const char* szField) const
+
+const char*
+CppSQLite3Table::fieldValue(const char* szField)
 {
-    checkResults();
+	checkResults();
 
-    if (szField)
-    {
-        for (int nField = 0; nField < mnCols; nField++)
-        {
-            if (strcmp(szField, mpaszResults[nField]) == 0)
-            {
-                int nIndex = (mnCurrentRow*mnCols) + mnCols + nField;
-                return mpaszResults[nIndex];
-            }
-        }
-    }
+	if (szField) {
+		for (int nField = 0; nField < mnCols; nField++) {
+			if (strcmp(szField, mpaszResults[nField]) == 0) {
+				int nIndex = (mnCurrentRow * mnCols) + mnCols + nField;
+				return mpaszResults[nIndex];
+			}
+		}
+	}
 
-    throw CppSQLite3Exception(CPPSQLITE_ERROR,
-                            "Invalid field name requested",
-                            DONT_DELETE_MSG);
+	throw CppSQLite3Exception(CPPSQLITE_ERROR, "Invalid field name requested", DONT_DELETE_MSG);
 }
 
 
-int CppSQLite3Table::getIntField(int nField, int nNullValue/*=0*/) const
+
+int
+CppSQLite3Table::getIntField(int nField, int nNullValue /*=0*/)
 {
-    if (fieldIsNull(nField))
-    {
-        return nNullValue;
-    }
-    else
-    {
-        return atoi(fieldValue(nField));
-    }
+	if (fieldIsNull(nField)) {
+		return nNullValue;
+	} else {
+		return atoi(fieldValue(nField));
+	}
 }
 
 
-int CppSQLite3Table::getIntField(const char* szField, int nNullValue/*=0*/) const
+
+int
+CppSQLite3Table::getIntField(const char* szField, int nNullValue /*=0*/)
 {
-    if (fieldIsNull(szField))
-    {
-        return nNullValue;
-    }
-    else
-    {
-        return atoi(fieldValue(szField));
-    }
+	if (fieldIsNull(szField)) {
+		return nNullValue;
+	} else {
+		return atoi(fieldValue(szField));
+	}
 }
 
 
-float CppSQLite3Table::getFloatField(int nField, float fNullValue/*=0.0f*/) const
+
+double
+CppSQLite3Table::getFloatField(int nField, double fNullValue /*=0.0*/)
 {
-    if (fieldIsNull(nField))
-    {
-        return fNullValue;
-    }
-    else
-    {
-        return static_cast<float>(atof(fieldValue(nField)));
-    }
+	if (fieldIsNull(nField)) {
+		return fNullValue;
+	} else {
+		return atof(fieldValue(nField));
+	}
 }
 
 
-float CppSQLite3Table::getFloatField(const char* szField, float fNullValue/*=0.0f*/) const
+
+double
+CppSQLite3Table::getFloatField(const char* szField, double fNullValue /*=0.0*/)
 {
-    if (fieldIsNull(szField))
-    {
-        return fNullValue;
-    }
-    else
-    {
-        return static_cast<float>(atof(fieldValue(szField)));
-    }
+	if (fieldIsNull(szField)) {
+		return fNullValue;
+	} else {
+		return atof(fieldValue(szField));
+	}
 }
 
 
-double CppSQLite3Table::getDoubleField(int nField, double dNullValue/*=0.0*/) const
+
+const char*
+CppSQLite3Table::getStringField(int nField, const char* szNullValue /*=""*/)
 {
-    if (fieldIsNull(nField))
-    {
-        return dNullValue;
-    }
-    else
-    {
-        return atof(fieldValue(nField));
-    }
+	if (fieldIsNull(nField)) {
+		return szNullValue;
+	} else {
+		return fieldValue(nField);
+	}
 }
 
 
-double CppSQLite3Table::getDoubleField(const char* szField, double dNullValue/*=0.0*/) const
+
+const char*
+CppSQLite3Table::getStringField(const char* szField, const char* szNullValue /*=""*/)
 {
-    if (fieldIsNull(szField))
-    {
-        return dNullValue;
-    }
-    else
-    {
-        return atof(fieldValue(szField));
-    }
+	if (fieldIsNull(szField)) {
+		return szNullValue;
+	} else {
+		return fieldValue(szField);
+	}
 }
 
 
-const char* CppSQLite3Table::getStringField(int nField, const char* szNullValue/*=""*/) const
+
+bool
+CppSQLite3Table::fieldIsNull(int nField)
 {
-    if (fieldIsNull(nField))
-    {
-        return szNullValue;
-    }
-    else
-    {
-        return fieldValue(nField);
-    }
+	checkResults();
+	return (fieldValue(nField) == 0);
 }
 
 
-const char* CppSQLite3Table::getStringField(const char* szField, const char* szNullValue/*=""*/) const
+
+bool
+CppSQLite3Table::fieldIsNull(const char* szField)
 {
-    if (fieldIsNull(szField))
-    {
-        return szNullValue;
-    }
-    else
-    {
-        return fieldValue(szField);
-    }
+	checkResults();
+	return (fieldValue(szField) == 0);
 }
 
 
-bool CppSQLite3Table::fieldIsNull(int nField) const
+
+const char*
+CppSQLite3Table::fieldName(int nCol)
 {
-    checkResults();
-    return (fieldValue(nField) == 0);
+	checkResults();
+
+	if (nCol < 0 || nCol > mnCols - 1) {
+		throw CppSQLite3Exception(
+			CPPSQLITE_ERROR, "Invalid field index requested", DONT_DELETE_MSG);
+	}
+
+	return mpaszResults[nCol];
 }
 
 
-bool CppSQLite3Table::fieldIsNull(const char* szField) const
+
+void
+CppSQLite3Table::setRow(int nRow)
 {
-    checkResults();
-    return (fieldValue(szField) == 0);
+	checkResults();
+
+	if (nRow < 0 || nRow > mnRows - 1) {
+		throw CppSQLite3Exception(CPPSQLITE_ERROR, "Invalid row index requested", DONT_DELETE_MSG);
+	}
+
+	mnCurrentRow = nRow;
 }
 
 
-const char* CppSQLite3Table::fieldName(int nCol) const
+
+void
+CppSQLite3Table::checkResults()
 {
-    checkResults();
-
-    if (nCol < 0 || nCol > mnCols-1)
-    {
-        throw CppSQLite3Exception(CPPSQLITE_ERROR,
-                                "Invalid field index requested",
-                                DONT_DELETE_MSG);
-    }
-
-    return mpaszResults[nCol];
+	if (mpaszResults == 0) {
+		throw CppSQLite3Exception(CPPSQLITE_ERROR, "Null Results pointer", DONT_DELETE_MSG);
+	}
 }
-
-
-void CppSQLite3Table::setRow(int nRow)
-{
-    checkResults();
-
-    if (nRow < 0 || nRow > mnRows-1)
-    {
-        throw CppSQLite3Exception(CPPSQLITE_ERROR,
-                                "Invalid row index requested",
-                                DONT_DELETE_MSG);
-    }
-
-    mnCurrentRow = nRow;
-}
-
-
-void CppSQLite3Table::checkResults() const
-{
-    if (mpaszResults == 0)
-    {
-        throw CppSQLite3Exception(CPPSQLITE_ERROR,
-                                "Null Results pointer",
-                                DONT_DELETE_MSG);
-    }
-}
-
 
 ////////////////////////////////////////////////////////////////////////////////
 
 CppSQLite3Statement::CppSQLite3Statement()
 {
-    mpDB = 0;
-    mpVM = 0;
+	mpDB = 0;
+	mpVM = 0;
 }
-
 
 CppSQLite3Statement::CppSQLite3Statement(const CppSQLite3Statement& rStatement)
 {
-    mpDB = rStatement.mpDB;
-    mpVM = rStatement.mpVM;
-    // Only one object can own VM
-    const_cast<CppSQLite3Statement&>(rStatement).mpVM = 0;
+	mpDB = rStatement.mpDB;
+	mpVM = rStatement.mpVM;
+	// Only one object can own VM
+	const_cast<CppSQLite3Statement&>(rStatement).mpVM = 0;
 }
-
 
 CppSQLite3Statement::CppSQLite3Statement(sqlite3* pDB, sqlite3_stmt* pVM)
 {
-    mpDB = pDB;
-    mpVM = pVM;
+	mpDB = pDB;
+	mpVM = pVM;
 }
-
 
 CppSQLite3Statement::~CppSQLite3Statement()
 {
-    try
-    {
-        finalize();
-    }
-    catch (...)
-    {
-    }
+	try {
+		finalize();
+	} catch (...) {
+	}
 }
 
 
-CppSQLite3Statement& CppSQLite3Statement::operator=(const CppSQLite3Statement& rStatement)
+
+CppSQLite3Statement&
+CppSQLite3Statement::operator=(const CppSQLite3Statement& rStatement)
 {
-    mpDB = rStatement.mpDB;
-    mpVM = rStatement.mpVM;
-    // Only one object can own VM
-    const_cast<CppSQLite3Statement&>(rStatement).mpVM = 0;
-    return *this;
+	mpDB = rStatement.mpDB;
+	mpVM = rStatement.mpVM;
+	// Only one object can own VM
+	const_cast<CppSQLite3Statement&>(rStatement).mpVM = 0;
+	return *this;
 }
 
 
-int CppSQLite3Statement::execDML()
+
+int
+CppSQLite3Statement::execDML()
 {
-    checkDB();
-    checkVM();
+	checkDB();
+	checkVM();
 
-    const char* szError=0;
+	const char* szError = 0;
 
-    int nRet = sqlite3_step(mpVM);
+	int nRet = sqlite3_step(mpVM);
 
-    if (nRet == SQLITE_DONE)
-    {
-        int nRowsChanged = sqlite3_changes(mpDB);
+	if (nRet == SQLITE_DONE) {
+		int nRowsChanged = sqlite3_changes(mpDB);
 
-        nRet = sqlite3_reset(mpVM);
+		nRet = sqlite3_reset(mpVM);
 
-        if (nRet != SQLITE_OK)
-        {
-            szError = sqlite3_errmsg(mpDB);
-            throw CppSQLite3Exception(nRet, (char*)szError, DONT_DELETE_MSG);
-        }
+		if (nRet != SQLITE_OK) {
+			szError = sqlite3_errmsg(mpDB);
+			throw CppSQLite3Exception(nRet, (char*)szError, DONT_DELETE_MSG);
+		}
 
-        return nRowsChanged;
-    }
-    else
-    {
-        nRet = sqlite3_reset(mpVM);
-        szError = sqlite3_errmsg(mpDB);
-        throw CppSQLite3Exception(nRet, (char*)szError, DONT_DELETE_MSG);
-    }
+		return nRowsChanged;
+	} else {
+		nRet = sqlite3_reset(mpVM);
+		szError = sqlite3_errmsg(mpDB);
+		throw CppSQLite3Exception(nRet, (char*)szError, DONT_DELETE_MSG);
+	}
 }
 
 
-CppSQLite3Query CppSQLite3Statement::execQuery()
+
+CppSQLite3Query
+CppSQLite3Statement::execQuery()
 {
-    checkDB();
-    checkVM();
+	checkDB();
+	checkVM();
 
-    int nRet = sqlite3_step(mpVM);
+	int nRet = sqlite3_step(mpVM);
 
-    if (nRet == SQLITE_DONE)
-    {
-        // no rows
-        return CppSQLite3Query(mpDB, mpVM, true/*eof*/, false);
-    }
-    else if (nRet == SQLITE_ROW)
-    {
-        // at least 1 row
-        return CppSQLite3Query(mpDB, mpVM, false/*eof*/, false);
-    }
-    else
-    {
-        nRet = sqlite3_reset(mpVM);
-        const char* szError = sqlite3_errmsg(mpDB);
-        throw CppSQLite3Exception(nRet, (char*)szError, DONT_DELETE_MSG);
-    }
+	if (nRet == SQLITE_DONE) {
+		// no rows
+		return CppSQLite3Query(mpDB, mpVM, true /*eof*/, false);
+	} else if (nRet == SQLITE_ROW) {
+		// at least 1 row
+		return CppSQLite3Query(mpDB, mpVM, false /*eof*/, false);
+	} else {
+		nRet = sqlite3_reset(mpVM);
+		const char* szError = sqlite3_errmsg(mpDB);
+		throw CppSQLite3Exception(nRet, (char*)szError, DONT_DELETE_MSG);
+	}
 }
 
 
-void CppSQLite3Statement::bind(int nParam, const char* szValue)
+
+void
+CppSQLite3Statement::bind(int nParam, const char* szValue)
 {
-    checkVM();
-    int nRes = sqlite3_bind_text(mpVM, nParam, szValue, -1, SQLITE_TRANSIENT);
+	checkVM();
+	int nRes = sqlite3_bind_text(mpVM, nParam, szValue, -1, SQLITE_TRANSIENT);
 
-    if (nRes != SQLITE_OK)
-    {
-        throw CppSQLite3Exception(nRes,
-                                "Error binding string param",
-                                DONT_DELETE_MSG);
-    }
+	if (nRes != SQLITE_OK) {
+		throw CppSQLite3Exception(nRes, "Error binding string param", DONT_DELETE_MSG);
+	}
 }
 
 
-void CppSQLite3Statement::bind(int nParam, const int nValue)
+
+void
+CppSQLite3Statement::bind(int nParam, const int nValue)
 {
-    checkVM();
-    int nRes = sqlite3_bind_int(mpVM, nParam, nValue);
+	checkVM();
+	int nRes = sqlite3_bind_int(mpVM, nParam, nValue);
 
-    if (nRes != SQLITE_OK)
-    {
-        throw CppSQLite3Exception(nRes,
-                                "Error binding int param",
-                                DONT_DELETE_MSG);
-    }
+	if (nRes != SQLITE_OK) {
+		throw CppSQLite3Exception(nRes, "Error binding int param", DONT_DELETE_MSG);
+	}
 }
 
 
-void CppSQLite3Statement::bind(int nParam, const long long nValue)
+
+void
+CppSQLite3Statement::bind(int nParam, const double dValue)
 {
-    checkVM();
-    int nRes = sqlite3_bind_int64(mpVM, nParam, nValue);
+	checkVM();
+	int nRes = sqlite3_bind_double(mpVM, nParam, dValue);
 
-    if (nRes != SQLITE_OK)
-    {
-        throw CppSQLite3Exception(nRes,
-                                  "Error binding int64 param",
-                                  DONT_DELETE_MSG);
-    }
+	if (nRes != SQLITE_OK) {
+		throw CppSQLite3Exception(nRes, "Error binding double param", DONT_DELETE_MSG);
+	}
 }
 
 
-void CppSQLite3Statement::bind(int nParam, const double dValue)
+
+void
+CppSQLite3Statement::bind(int nParam, const unsigned char* blobValue, int nLen)
 {
-    checkVM();
-    int nRes = sqlite3_bind_double(mpVM, nParam, dValue);
+	checkVM();
+	int nRes = sqlite3_bind_blob(mpVM, nParam, (const void*)blobValue, nLen, SQLITE_TRANSIENT);
 
-    if (nRes != SQLITE_OK)
-    {
-        throw CppSQLite3Exception(nRes,
-                                "Error binding double param",
-                                DONT_DELETE_MSG);
-    }
+	if (nRes != SQLITE_OK) {
+		throw CppSQLite3Exception(nRes, "Error binding blob param", DONT_DELETE_MSG);
+	}
 }
 
 
-void CppSQLite3Statement::bind(int nParam, const unsigned char* blobValue, int nLen)
+
+void
+CppSQLite3Statement::bindNull(int nParam)
 {
-    checkVM();
-    int nRes = sqlite3_bind_blob(mpVM, nParam,
-                                (const void*)blobValue, nLen, SQLITE_TRANSIENT);
+	checkVM();
+	int nRes = sqlite3_bind_null(mpVM, nParam);
 
-    if (nRes != SQLITE_OK)
-    {
-        throw CppSQLite3Exception(nRes,
-                                "Error binding blob param",
-                                DONT_DELETE_MSG);
-    }
+	if (nRes != SQLITE_OK) {
+		throw CppSQLite3Exception(nRes, "Error binding NULL param", DONT_DELETE_MSG);
+	}
 }
 
 
-void CppSQLite3Statement::bindNull(int nParam)
+
+int
+CppSQLite3Statement::bindParameterIndex(const char* szParam)
 {
-    checkVM();
-    int nRes = sqlite3_bind_null(mpVM, nParam);
+	checkVM();
 
-    if (nRes != SQLITE_OK)
-    {
-        throw CppSQLite3Exception(nRes,
-                                "Error binding NULL param",
-                                DONT_DELETE_MSG);
-    }
+	int nParam = sqlite3_bind_parameter_index(mpVM, szParam);
+
+	int nn = sqlite3_bind_parameter_count(mpVM);
+	const char* sz1 = sqlite3_bind_parameter_name(mpVM, 1);
+	const char* sz2 = sqlite3_bind_parameter_name(mpVM, 2);
+
+	if (!nParam) {
+		char buf[128];
+		sprintf(buf, "Parameter '%s' is not valid for this statement", szParam);
+		throw CppSQLite3Exception(CPPSQLITE_ERROR, buf, DONT_DELETE_MSG);
+	}
+
+	return nParam;
 }
 
 
-void CppSQLite3Statement::reset()
+
+void
+CppSQLite3Statement::bind(const char* szParam, const char* szValue)
 {
-    if (mpVM)
-    {
-        int nRet = sqlite3_reset(mpVM);
-
-        if (nRet != SQLITE_OK)
-        {
-            const char* szError = sqlite3_errmsg(mpDB);
-            throw CppSQLite3Exception(nRet, (char*)szError, DONT_DELETE_MSG);
-        }
-    }
+	int nParam = bindParameterIndex(szParam);
+	bind(nParam, szValue);
 }
 
 
-void CppSQLite3Statement::finalize()
+
+void
+CppSQLite3Statement::bind(const char* szParam, const int nValue)
 {
-    if (mpVM)
-    {
-        int nRet = sqlite3_finalize(mpVM);
-        mpVM = 0;
-
-        if (nRet != SQLITE_OK)
-        {
-            const char* szError = sqlite3_errmsg(mpDB);
-            throw CppSQLite3Exception(nRet, (char*)szError, DONT_DELETE_MSG);
-        }
-    }
+	int nParam = bindParameterIndex(szParam);
+	bind(nParam, nValue);
 }
 
-
-void CppSQLite3Statement::checkDB() const
+void
+CppSQLite3Statement::bind(const char* szParam, const double dwValue)
 {
-    if (mpDB == 0)
-    {
-        throw CppSQLite3Exception(CPPSQLITE_ERROR,
-                                "Database not open",
-                                DONT_DELETE_MSG);
-    }
+	int nParam = bindParameterIndex(szParam);
+	bind(nParam, dwValue);
 }
 
-
-void CppSQLite3Statement::checkVM() const
+void
+CppSQLite3Statement::bind(const char* szParam, const unsigned char* blobValue, int nLen)
 {
-    if (mpVM == 0)
-    {
-        throw CppSQLite3Exception(CPPSQLITE_ERROR,
-                                "Null Virtual Machine pointer",
-                                DONT_DELETE_MSG);
-    }
+	int nParam = bindParameterIndex(szParam);
+	bind(nParam, blobValue, nLen);
 }
 
+
+
+void
+CppSQLite3Statement::bindNull(const char* szParam)
+{
+	int nParam = bindParameterIndex(szParam);
+	bindNull(nParam);
+}
+
+
+
+void
+CppSQLite3Statement::reset()
+{
+	if (mpVM) {
+		int nRet = sqlite3_reset(mpVM);
+
+		if (nRet != SQLITE_OK) {
+			const char* szError = sqlite3_errmsg(mpDB);
+			throw CppSQLite3Exception(nRet, (char*)szError, DONT_DELETE_MSG);
+		}
+	}
+}
+
+
+
+void
+CppSQLite3Statement::finalize()
+{
+	if (mpVM) {
+		int nRet = sqlite3_finalize(mpVM);
+		mpVM = 0;
+
+		if (nRet != SQLITE_OK) {
+			const char* szError = sqlite3_errmsg(mpDB);
+			throw CppSQLite3Exception(nRet, (char*)szError, DONT_DELETE_MSG);
+		}
+	}
+}
+
+
+
+void
+CppSQLite3Statement::checkDB()
+{
+	if (mpDB == 0) {
+		throw CppSQLite3Exception(CPPSQLITE_ERROR, "Database not open", DONT_DELETE_MSG);
+	}
+}
+
+
+
+void
+CppSQLite3Statement::checkVM()
+{
+	if (mpVM == 0) {
+		throw CppSQLite3Exception(CPPSQLITE_ERROR, "Null Virtual Machine pointer", DONT_DELETE_MSG);
+	}
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 
 CppSQLite3DB::CppSQLite3DB()
 {
-    mpDB = 0;
-    mnBusyTimeoutMs = 60000; // 60 seconds
+	mpDB = 0;
+	mnBusyTimeoutMs = 60000;  // 60 seconds
 }
-
 
 CppSQLite3DB::CppSQLite3DB(const CppSQLite3DB& db)
 {
-    mpDB = db.mpDB;
-    mnBusyTimeoutMs = 60000; // 60 seconds
+	mpDB = db.mpDB;
+	mnBusyTimeoutMs = 60000;  // 60 seconds
 }
-
 
 CppSQLite3DB::~CppSQLite3DB()
 {
-    close();
+	try {
+		close();
+	} catch (...) {
+	}
 }
 
 
-CppSQLite3DB& CppSQLite3DB::operator=(const CppSQLite3DB& db)
+
+CppSQLite3DB&
+CppSQLite3DB::operator=(const CppSQLite3DB& db)
 {
-    mpDB = db.mpDB;
-    mnBusyTimeoutMs = 60000; // 60 seconds
-    return *this;
+	mpDB = db.mpDB;
+	mnBusyTimeoutMs = 60000;  // 60 seconds
+	return *this;
 }
 
 
-void CppSQLite3DB::open(const char* szFile)
+
+void
+CppSQLite3DB::open(const char* szFile)
 {
-    int nRet = sqlite3_open(szFile, &mpDB);
+	int nRet = sqlite3_open(szFile, &mpDB);
 
-    if (nRet != SQLITE_OK)
-    {
-        const char* szError = sqlite3_errmsg(mpDB);
-        throw CppSQLite3Exception(nRet, (char*)szError, DONT_DELETE_MSG);
-    }
+	if (nRet != SQLITE_OK) {
+		const char* szError = sqlite3_errmsg(mpDB);
+		throw CppSQLite3Exception(nRet, (char*)szError, DONT_DELETE_MSG);
+	}
 
-    setBusyTimeout(mnBusyTimeoutMs);
+	setBusyTimeout(mnBusyTimeoutMs);
 }
 
 
-void CppSQLite3DB::close()
+
+void
+CppSQLite3DB::close()
 {
-    if (mpDB)
-    {
-        sqlite3_close(mpDB);
-        mpDB = 0;
-    }
+	if (mpDB) {
+		if (sqlite3_close(mpDB) == SQLITE_OK) {
+			mpDB = 0;
+		} else {
+			throw CppSQLite3Exception(CPPSQLITE_ERROR, "Unable to close database", DONT_DELETE_MSG);
+		}
+	}
 }
 
 
-CppSQLite3Statement CppSQLite3DB::compileStatement(const char* szSQL)
+
+CppSQLite3Statement
+CppSQLite3DB::compileStatement(const char* szSQL)
 {
-    checkDB();
+	checkDB();
 
-    sqlite3_stmt* pVM = compile(szSQL);
-    return CppSQLite3Statement(mpDB, pVM);
+	sqlite3_stmt* pVM = compile(szSQL);
+	return CppSQLite3Statement(mpDB, pVM);
 }
 
 
-bool CppSQLite3DB::tableExists(const char* szTable)
+
+bool
+CppSQLite3DB::tableExists(const char* szTable)
 {
-    CppSQLite3Buffer sql;
-    sql.format( "select count(*) from sqlite_master where type='table' and name=%Q",
-                szTable );
-    int nRet = execScalar(sql);
-    return (nRet > 0);
+	char szSQL[256];
+	sprintf(szSQL, "select count(*) from sqlite_master where type='table' and name='%s'", szTable);
+	int nRet = execScalar(szSQL);
+	return (nRet > 0);
 }
 
 
-int CppSQLite3DB::execDML(const char* szSQL)
+
+int
+CppSQLite3DB::execDML(const char* szSQL)
 {
-    checkDB();
+	checkDB();
 
-    char* szError=0;
+	char* szError = 0;
 
-    int nRet = sqlite3_exec(mpDB, szSQL, 0, 0, &szError);
+	int nRet = sqlite3_exec(mpDB, szSQL, 0, 0, &szError);
 
-    if (nRet == SQLITE_OK)
-    {
-        return sqlite3_changes(mpDB);
-    }
-    else
-    {
-        throw CppSQLite3Exception(nRet, szError);
-    }
+	if (nRet == SQLITE_OK) {
+		return sqlite3_changes(mpDB);
+	} else {
+		throw CppSQLite3Exception(nRet, szError);
+	}
 }
 
 
-CppSQLite3Query CppSQLite3DB::execQuery(const char* szSQL)
+
+CppSQLite3Query
+CppSQLite3DB::execQuery(const char* szSQL)
 {
-    checkDB();
+	checkDB();
 
-    sqlite3_stmt* pVM = compile(szSQL);
+	sqlite3_stmt* pVM = compile(szSQL);
 
-    int nRet = sqlite3_step(pVM);
+	int nRet = sqlite3_step(pVM);
 
-    if (nRet == SQLITE_DONE)
-    {
-        // no rows
-        return CppSQLite3Query(mpDB, pVM, true/*eof*/);
-    }
-    else if (nRet == SQLITE_ROW)
-    {
-        // at least 1 row
-        return CppSQLite3Query(mpDB, pVM, false/*eof*/);
-    }
-    else
-    {
-        nRet = sqlite3_finalize(pVM);
-        const char* szError= sqlite3_errmsg(mpDB);
-        throw CppSQLite3Exception(nRet, (char*)szError, DONT_DELETE_MSG);
-    }
+	if (nRet == SQLITE_DONE) {
+		// no rows
+		return CppSQLite3Query(mpDB, pVM, true /*eof*/);
+	} else if (nRet == SQLITE_ROW) {
+		// at least 1 row
+		return CppSQLite3Query(mpDB, pVM, false /*eof*/);
+	} else {
+		nRet = sqlite3_finalize(pVM);
+		const char* szError = sqlite3_errmsg(mpDB);
+		throw CppSQLite3Exception(nRet, (char*)szError, DONT_DELETE_MSG);
+	}
 }
 
 
-int CppSQLite3DB::execScalar(const char* szSQL)
+
+int
+CppSQLite3DB::execScalar(const char* szSQL, int nNullValue /*=0*/)
 {
-    CppSQLite3Query q = execQuery(szSQL);
+	CppSQLite3Query q = execQuery(szSQL);
 
-    if (q.eof() || q.numFields() < 1)
-    {
-        throw CppSQLite3Exception(CPPSQLITE_ERROR,
-                                "Invalid scalar query",
-                                DONT_DELETE_MSG);
-    }
+	if (q.eof() || q.numFields() < 1) {
+		throw CppSQLite3Exception(CPPSQLITE_ERROR, "Invalid scalar query", DONT_DELETE_MSG);
+	}
 
-    return atoi(q.fieldValue(0));
+	return q.getIntField(0, nNullValue);
 }
 
 
-CppSQLite3Table CppSQLite3DB::getTable(const char* szSQL)
+
+CppSQLite3Table
+CppSQLite3DB::getTable(const char* szSQL)
 {
-    checkDB();
+	checkDB();
 
-    char* szError=0;
-    char** paszResults=0;
-    int nRet;
-    int nRows(0);
-    int nCols(0);
+	char* szError = 0;
+	char** paszResults = 0;
+	int nRet;
+	int nRows(0);
+	int nCols(0);
 
-    nRet = sqlite3_get_table(mpDB, szSQL, &paszResults, &nRows, &nCols, &szError);
+	nRet = sqlite3_get_table(mpDB, szSQL, &paszResults, &nRows, &nCols, &szError);
 
-    if (nRet == SQLITE_OK)
-    {
-        return CppSQLite3Table(paszResults, nRows, nCols);
-    }
-    else
-    {
-        throw CppSQLite3Exception(nRet, szError);
-    }
+	if (nRet == SQLITE_OK) {
+		return CppSQLite3Table(paszResults, nRows, nCols);
+	} else {
+		throw CppSQLite3Exception(nRet, szError);
+	}
 }
 
 
-sqlite_int64 CppSQLite3DB::lastRowId() const
+
+sqlite_int64
+CppSQLite3DB::lastRowId()
 {
-    return sqlite3_last_insert_rowid(mpDB);
+	return sqlite3_last_insert_rowid(mpDB);
 }
 
 
-void CppSQLite3DB::setBusyTimeout(int nMillisecs)
+
+void
+CppSQLite3DB::setBusyTimeout(int nMillisecs)
 {
-    mnBusyTimeoutMs = nMillisecs;
-    sqlite3_busy_timeout(mpDB, mnBusyTimeoutMs);
+	mnBusyTimeoutMs = nMillisecs;
+	sqlite3_busy_timeout(mpDB, mnBusyTimeoutMs);
 }
 
 
-void CppSQLite3DB::checkDB() const
+
+void
+CppSQLite3DB::checkDB()
 {
-    if (!mpDB)
-    {
-        throw CppSQLite3Exception(CPPSQLITE_ERROR,
-                                "Database not open",
-                                DONT_DELETE_MSG);
-    }
+	if (!mpDB) {
+		throw CppSQLite3Exception(CPPSQLITE_ERROR, "Database not open", DONT_DELETE_MSG);
+	}
 }
 
 
-sqlite3_stmt* CppSQLite3DB::compile(const char* szSQL)
+
+sqlite3_stmt*
+CppSQLite3DB::compile(const char* szSQL)
 {
-    checkDB();
+	checkDB();
 
-    char* szError=0;
-    const char* szTail=0;
-    sqlite3_stmt* pVM;
+	const char* szTail = 0;
+	sqlite3_stmt* pVM;
 
-    int nRet = sqlite3_prepare(mpDB, szSQL, -1, &pVM, &szTail);
+	int nRet = sqlite3_prepare_v2(mpDB, szSQL, -1, &pVM, &szTail);
 
-    if (nRet != SQLITE_OK)
-    {
-        throw CppSQLite3Exception(nRet, szError);
-    }
+	if (nRet != SQLITE_OK) {
+		const char* szError = sqlite3_errmsg(mpDB);
+		throw CppSQLite3Exception(nRet, (char*)szError, DONT_DELETE_MSG);
+	}
 
-    return pVM;
+	return pVM;
 }
 
+bool
+CppSQLite3DB::IsAutoCommitOn()
+{
+	checkDB();
+	return sqlite3_get_autocommit(mpDB) ? true : false;
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 // SQLite encode.c reproduced here, containing implementation notes and source
@@ -1552,46 +1482,52 @@ sqlite3_stmt* CppSQLite3DB::compile(const char* szSQL)
 ** The return value is the number of characters in the encoded
 ** string, excluding the "\000" terminator.
 */
-int sqlite3_encode_binary(const unsigned char *in, int n, unsigned char *out){
-  int i, j, e, m;
-  int cnt[256];
-  if( n<=0 ){
-    out[0] = 'x';
-    out[1] = 0;
-    return 1;
-  }
-  memset(cnt, 0, sizeof(cnt));
-  for(i=n-1; i>=0; i--){ cnt[in[i]]++; }
-  m = n;
-  for(i=1; i<256; i++){
-    int sum;
-    if( i=='\'' ) continue;
-    sum = cnt[i] + cnt[(i+1)&0xff] + cnt[(i+'\'')&0xff];
-    if( sum<m ){
-      m = sum;
-      e = i;
-      if( m==0 ) break;
-    }
-  }
-  out[0] = e;
-  j = 1;
-  for(i=0; i<n; i++){
-    int c = (in[i] - e)&0xff;
-    if( c==0 ){
-      out[j++] = 1;
-      out[j++] = 1;
-    }else if( c==1 ){
-      out[j++] = 1;
-      out[j++] = 2;
-    }else if( c=='\'' ){
-      out[j++] = 1;
-      out[j++] = 3;
-    }else{
-      out[j++] = c;
-    }
-  }
-  out[j] = 0;
-  return j;
+int
+sqlite3_encode_binary(const unsigned char* in, int n, unsigned char* out)
+{
+	int i, j, e, m;
+	int cnt[256];
+	if (n <= 0) {
+		out[0] = 'x';
+		out[1] = 0;
+		return 1;
+	}
+	memset(cnt, 0, sizeof(cnt));
+	for (i = n - 1; i >= 0; i--) {
+		cnt[in[i]]++;
+	}
+	m = n;
+	for (i = 1; i < 256; i++) {
+		int sum;
+		if (i == '\'')
+			continue;
+		sum = cnt[i] + cnt[(i + 1) & 0xff] + cnt[(i + '\'') & 0xff];
+		if (sum < m) {
+			m = sum;
+			e = i;
+			if (m == 0)
+				break;
+		}
+	}
+	out[0] = e;
+	j = 1;
+	for (i = 0; i < n; i++) {
+		int c = (in[i] - e) & 0xff;
+		if (c == 0) {
+			out[j++] = 1;
+			out[j++] = 1;
+		} else if (c == 1) {
+			out[j++] = 1;
+			out[j++] = 2;
+		} else if (c == '\'') {
+			out[j++] = 1;
+			out[j++] = 3;
+		} else {
+			out[j++] = c;
+		}
+	}
+	out[j] = 0;
+	return j;
 }
 
 /*
@@ -1604,24 +1540,26 @@ int sqlite3_encode_binary(const unsigned char *in, int n, unsigned char *out){
 ** The "in" and "out" parameters may point to the same buffer in order
 ** to decode a string in place.
 */
-int sqlite3_decode_binary(const unsigned char *in, unsigned char *out){
-  int i, c, e;
-  e = *(in++);
-  i = 0;
-  while( (c = *(in++))!=0 ){
-    if( c==1 ){
-      c = *(in++);
-      if( c==1 ){
-        c = 0;
-      }else if( c==2 ){
-        c = 1;
-      }else if( c==3 ){
-        c = '\'';
-      }else{
-        return -1;
-      }
-    }
-    out[i++] = (c + e)&0xff;
-  }
-  return i;
+int
+sqlite3_decode_binary(const unsigned char* in, unsigned char* out)
+{
+	int i, c, e;
+	e = *(in++);
+	i = 0;
+	while ((c = *(in++)) != 0) {
+		if (c == 1) {
+			c = *(in++);
+			if (c == 1) {
+				c = 0;
+			} else if (c == 2) {
+				c = 1;
+			} else if (c == 3) {
+				c = '\'';
+			} else {
+				return -1;
+			}
+		}
+		out[i++] = (c + e) & 0xff;
+	}
+	return i;
 }

--- a/src/CppSQLite3.cpp
+++ b/src/CppSQLite3.cpp
@@ -1,1304 +1,1435 @@
-////////////////////////////////////////////////////////////////////////////////
-// CppSQLite3 - A C++ wrapper around the SQLite3 embedded database library.
-//
-// Copyright (c) 2004..2007 Rob Groves. All Rights Reserved. rob.groves@btinternet.com
-//
-// Permission to use, copy, modify, and distribute this software and its
-// documentation for any purpose, without fee, and without a written
-// agreement, is hereby granted, provided that the above copyright notice,
-// this paragraph and the following two paragraphs appear in all copies,
-// modifications, and distributions.
-//
-// IN NO EVENT SHALL THE AUTHOR BE LIABLE TO ANY PARTY FOR DIRECT,
-// INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST
-// PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
-// EVEN IF THE AUTHOR HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
-// THE AUTHOR SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-// PARTICULAR PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF
-// ANY, PROVIDED HEREUNDER IS PROVIDED "AS IS". THE AUTHOR HAS NO OBLIGATION
-// TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
-//
-// V3.0		03/08/2004	-Initial Version for sqlite3
-//
-// V3.1		16/09/2004	-Implemented getXXXXField using sqlite3 functions
-//						-Added CppSQLiteDB3::tableExists()
-//
-// V3.2		01/07/2005	-Fixed execScalar to handle a NULL result
-//			12/07/2007	-Added int64 functions to CppSQLite3Query
-//						-Throw exception from CppSQLite3DB::close() if error
-//						-Trap above exception in CppSQLite3DB::~CppSQLite3DB()
-//						-Fix to CppSQLite3DB::compile() as provided by Dave Rollins.
-//						-sqlite3_prepare replaced with sqlite3_prepare_v2
-//						-Added Name based parameter binding to CppSQLite3Statement.
-////////////////////////////////////////////////////////////////////////////////
+/*
+ * CppSQLite
+ * Developed by Rob Groves <rob.groves@btinternet.com>
+ * Maintained by NeoSmart Technologies <http://neosmart.net/>
+ * See LICENSE file for copyright and license info
+*/
+
 #include "CppSQLite3.h"
 #include <cstdlib>
+#include <utility>
 
 
 // Named constant for passing to CppSQLite3Exception when passing it a string
 // that cannot be deleted.
-static const bool DONT_DELETE_MSG = false;
+static const bool DONT_DELETE_MSG=false;
+
+// Error message used when throwing CppSQLite3Exception when allocations fail.
+static const char* const ALLOCATION_ERROR_MESSAGE = "Cannot allocate memory";
 
 ////////////////////////////////////////////////////////////////////////////////
 // Prototypes for SQLite functions not included in SQLite DLL, but copied below
 // from SQLite encode.c
 ////////////////////////////////////////////////////////////////////////////////
-int sqlite3_encode_binary(const unsigned char* in, int n, unsigned char* out);
-int sqlite3_decode_binary(const unsigned char* in, unsigned char* out);
+int sqlite3_encode_binary(const unsigned char *in, int n, unsigned char *out);
+int sqlite3_decode_binary(const unsigned char *in, unsigned char *out);
 
 ////////////////////////////////////////////////////////////////////////////////
 
+namespace detail
+{
+
+SQLite3Memory::SQLite3Memory() :
+    mnBufferLen(0),
+    mpBuf(nullptr)
+{
+}
+
+SQLite3Memory::SQLite3Memory(int nBufferLen) :
+    mnBufferLen(nBufferLen),
+    mpBuf(sqlite3_malloc(nBufferLen))
+{
+    if (!mpBuf && mnBufferLen>0)
+    {
+        throw CppSQLite3Exception(CPPSQLITE_ERROR,
+                                ALLOCATION_ERROR_MESSAGE,
+                                DONT_DELETE_MSG);
+    }
+}
+
+SQLite3Memory::SQLite3Memory(const char* szFormat, va_list list) :
+    mnBufferLen(0),
+    mpBuf(sqlite3_vmprintf(szFormat, list))
+{
+    if (!mpBuf)
+    {
+        throw CppSQLite3Exception(CPPSQLITE_ERROR,
+                                ALLOCATION_ERROR_MESSAGE,
+                                DONT_DELETE_MSG);
+    }
+    mnBufferLen = std::strlen(static_cast<char const*>(mpBuf))+1;
+}
+
+SQLite3Memory::~SQLite3Memory()
+{
+    clear();
+}
+
+SQLite3Memory::SQLite3Memory(SQLite3Memory const& other) :
+    mnBufferLen(other.mnBufferLen),
+    mpBuf(sqlite3_malloc(other.mnBufferLen))
+{
+    if (!mpBuf && mnBufferLen>0)
+    {
+        throw CppSQLite3Exception(CPPSQLITE_ERROR,
+                                ALLOCATION_ERROR_MESSAGE,
+                                DONT_DELETE_MSG);
+    }
+    std::memcpy(mpBuf, other.mpBuf, mnBufferLen);
+}
+
+SQLite3Memory& SQLite3Memory::operator=(SQLite3Memory const& lhs)
+{
+    SQLite3Memory tmp(lhs);
+    swap(tmp);
+    return *this;
+}
+
+SQLite3Memory::SQLite3Memory(SQLite3Memory&& other) :
+    mnBufferLen(other.mnBufferLen),
+    mpBuf(other.mpBuf)
+{
+    other.mnBufferLen = 0;
+    other.mpBuf = nullptr;
+}
+
+SQLite3Memory& SQLite3Memory::operator=(SQLite3Memory&& lhs)
+{
+    swap(lhs);
+    return *this;
+}
+
+void SQLite3Memory::swap(SQLite3Memory& other)
+{
+    std::swap(mnBufferLen, other.mnBufferLen);
+    std::swap(mpBuf, other.mpBuf);
+}
+
+void SQLite3Memory::clear()
+{
+    sqlite3_free(mpBuf);
+    mpBuf = nullptr;
+    mnBufferLen = 0;
+}
+
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
-CppSQLite3Exception::CppSQLite3Exception(
-	const int nErrCode, char* szErrMess, bool bDeleteMsg /*=true*/)
-	: mnErrCode(nErrCode)
+CppSQLite3Exception::CppSQLite3Exception(const int nErrCode,
+                                    const char* szErrMess,
+                                    bool bDeleteMsg/*=true*/) :
+                                    mnErrCode(nErrCode)
 {
-	mpszErrMess = sqlite3_mprintf(
-		"%s[%d]: %s", errorCodeAsString(nErrCode), nErrCode, szErrMess ? szErrMess : "");
+    mpszErrMess = sqlite3_mprintf("%s[%d]: %s",
+                                errorCodeAsString(nErrCode),
+                                nErrCode,
+                                szErrMess ? szErrMess : "");
 
-	if (bDeleteMsg && szErrMess) {
-		sqlite3_free(szErrMess);
-	}
+    if (bDeleteMsg && szErrMess)
+    {
+        sqlite3_free((void*)szErrMess);
+    }
 }
 
 
-CppSQLite3Exception::CppSQLite3Exception(const CppSQLite3Exception& e) : mnErrCode(e.mnErrCode)
+CppSQLite3Exception::CppSQLite3Exception(const CppSQLite3Exception&  e) :
+                                    mnErrCode(e.mnErrCode)
 {
-	mpszErrMess = 0;
-	if (e.mpszErrMess) {
-		mpszErrMess = sqlite3_mprintf("%s", e.mpszErrMess);
-	}
+    mpszErrMess = 0;
+    if (e.mpszErrMess)
+    {
+        mpszErrMess = sqlite3_mprintf("%s", e.mpszErrMess);
+    }
 }
 
 
-const char*
-CppSQLite3Exception::errorCodeAsString(int nErrCode)
+const char* CppSQLite3Exception::errorCodeAsString(int nErrCode)
 {
-	switch (nErrCode) {
-		case SQLITE_OK:
-			return "SQLITE_OK";
-		case SQLITE_ERROR:
-			return "SQLITE_ERROR";
-		case SQLITE_INTERNAL:
-			return "SQLITE_INTERNAL";
-		case SQLITE_PERM:
-			return "SQLITE_PERM";
-		case SQLITE_ABORT:
-			return "SQLITE_ABORT";
-		case SQLITE_BUSY:
-			return "SQLITE_BUSY";
-		case SQLITE_LOCKED:
-			return "SQLITE_LOCKED";
-		case SQLITE_NOMEM:
-			return "SQLITE_NOMEM";
-		case SQLITE_READONLY:
-			return "SQLITE_READONLY";
-		case SQLITE_INTERRUPT:
-			return "SQLITE_INTERRUPT";
-		case SQLITE_IOERR:
-			return "SQLITE_IOERR";
-		case SQLITE_CORRUPT:
-			return "SQLITE_CORRUPT";
-		case SQLITE_NOTFOUND:
-			return "SQLITE_NOTFOUND";
-		case SQLITE_FULL:
-			return "SQLITE_FULL";
-		case SQLITE_CANTOPEN:
-			return "SQLITE_CANTOPEN";
-		case SQLITE_PROTOCOL:
-			return "SQLITE_PROTOCOL";
-		case SQLITE_EMPTY:
-			return "SQLITE_EMPTY";
-		case SQLITE_SCHEMA:
-			return "SQLITE_SCHEMA";
-		case SQLITE_TOOBIG:
-			return "SQLITE_TOOBIG";
-		case SQLITE_CONSTRAINT:
-			return "SQLITE_CONSTRAINT";
-		case SQLITE_MISMATCH:
-			return "SQLITE_MISMATCH";
-		case SQLITE_MISUSE:
-			return "SQLITE_MISUSE";
-		case SQLITE_NOLFS:
-			return "SQLITE_NOLFS";
-		case SQLITE_AUTH:
-			return "SQLITE_AUTH";
-		case SQLITE_FORMAT:
-			return "SQLITE_FORMAT";
-		case SQLITE_RANGE:
-			return "SQLITE_RANGE";
-		case SQLITE_ROW:
-			return "SQLITE_ROW";
-		case SQLITE_DONE:
-			return "SQLITE_DONE";
-		case CPPSQLITE_ERROR:
-			return "CPPSQLITE_ERROR";
-		default:
-			return "UNKNOWN_ERROR";
-	}
+    switch (nErrCode)
+    {
+        case SQLITE_OK          : return "SQLITE_OK";
+        case SQLITE_ERROR       : return "SQLITE_ERROR";
+        case SQLITE_INTERNAL    : return "SQLITE_INTERNAL";
+        case SQLITE_PERM        : return "SQLITE_PERM";
+        case SQLITE_ABORT       : return "SQLITE_ABORT";
+        case SQLITE_BUSY        : return "SQLITE_BUSY";
+        case SQLITE_LOCKED      : return "SQLITE_LOCKED";
+        case SQLITE_NOMEM       : return "SQLITE_NOMEM";
+        case SQLITE_READONLY    : return "SQLITE_READONLY";
+        case SQLITE_INTERRUPT   : return "SQLITE_INTERRUPT";
+        case SQLITE_IOERR       : return "SQLITE_IOERR";
+        case SQLITE_CORRUPT     : return "SQLITE_CORRUPT";
+        case SQLITE_NOTFOUND    : return "SQLITE_NOTFOUND";
+        case SQLITE_FULL        : return "SQLITE_FULL";
+        case SQLITE_CANTOPEN    : return "SQLITE_CANTOPEN";
+        case SQLITE_PROTOCOL    : return "SQLITE_PROTOCOL";
+        case SQLITE_EMPTY       : return "SQLITE_EMPTY";
+        case SQLITE_SCHEMA      : return "SQLITE_SCHEMA";
+        case SQLITE_TOOBIG      : return "SQLITE_TOOBIG";
+        case SQLITE_CONSTRAINT  : return "SQLITE_CONSTRAINT";
+        case SQLITE_MISMATCH    : return "SQLITE_MISMATCH";
+        case SQLITE_MISUSE      : return "SQLITE_MISUSE";
+        case SQLITE_NOLFS       : return "SQLITE_NOLFS";
+        case SQLITE_AUTH        : return "SQLITE_AUTH";
+        case SQLITE_FORMAT      : return "SQLITE_FORMAT";
+        case SQLITE_RANGE       : return "SQLITE_RANGE";
+        case SQLITE_ROW         : return "SQLITE_ROW";
+        case SQLITE_DONE        : return "SQLITE_DONE";
+        case CPPSQLITE_ERROR    : return "CPPSQLITE_ERROR";
+        default: return "UNKNOWN_ERROR";
+    }
 }
+
 
 CppSQLite3Exception::~CppSQLite3Exception()
 {
-	if (mpszErrMess) {
-		sqlite3_free(mpszErrMess);
-		mpszErrMess = 0;
-	}
+    if (mpszErrMess)
+    {
+        sqlite3_free(mpszErrMess);
+        mpszErrMess = 0;
+    }
 }
+
 
 ////////////////////////////////////////////////////////////////////////////////
 
-CppSQLite3Buffer::CppSQLite3Buffer()
+void CppSQLite3Buffer::clear()
 {
-	mpBuf = 0;
-}
-
-CppSQLite3Buffer::~CppSQLite3Buffer()
-{
-	clear();
+    mBuf.clear();
 }
 
 
-void
-CppSQLite3Buffer::clear()
+const char* CppSQLite3Buffer::format(const char* szFormat, ...)
 {
-	if (mpBuf) {
-		sqlite3_free(mpBuf);
-		mpBuf = 0;
-	}
+    va_list va;
+    detail::SQLite3Memory tmpBuf;
+    try
+    {
+        va_start(va, szFormat);
+        tmpBuf = detail::SQLite3Memory(szFormat, va);
+        va_end(va);
+    }
+    catch(CppSQLite3Exception&)
+    {
+        va_end(va);
+        throw;
+    }
+    mBuf = std::move(tmpBuf);
+    return static_cast<const char*>(mBuf.getBuffer());
 }
 
-
-const char*
-CppSQLite3Buffer::format(const char* szFormat, ...)
-{
-	clear();
-	va_list va;
-	va_start(va, szFormat);
-	mpBuf = sqlite3_vmprintf(szFormat, va);
-	va_end(va);
-	return mpBuf;
-}
 
 ////////////////////////////////////////////////////////////////////////////////
 
-CppSQLite3Binary::CppSQLite3Binary()
-	: mpBuf(0), mnBinaryLen(0), mnBufferLen(0), mnEncodedLen(0), mbEncoded(false)
+CppSQLite3Binary::CppSQLite3Binary() :
+                        mpBuf(0),
+                        mnBinaryLen(0),
+                        mnBufferLen(0),
+                        mnEncodedLen(0),
+                        mbEncoded(false)
 {
 }
+
 
 CppSQLite3Binary::~CppSQLite3Binary()
 {
-	clear();
+    clear();
 }
 
 
-void
-CppSQLite3Binary::setBinary(const unsigned char* pBuf, int nLen)
+void CppSQLite3Binary::setBinary(const unsigned char* pBuf, int nLen)
 {
-	mpBuf = allocBuffer(nLen);
-	memcpy(mpBuf, pBuf, nLen);
+    mpBuf = allocBuffer(nLen);
+    memcpy(mpBuf, pBuf, nLen);
 }
 
 
-void
-CppSQLite3Binary::setEncoded(const unsigned char* pBuf)
+void CppSQLite3Binary::setEncoded(const unsigned char* pBuf)
 {
-	clear();
+    clear();
 
-	mnEncodedLen = strlen((const char*)pBuf);
-	mnBufferLen = mnEncodedLen + 1;	 // Allow for NULL terminator
+    mnEncodedLen = strlen((const char*)pBuf);
+    mnBufferLen = mnEncodedLen + 1; // Allow for NULL terminator
 
-	mpBuf = (unsigned char*)malloc(mnBufferLen);
+    mpBuf = (unsigned char*)malloc(mnBufferLen);
 
-	if (!mpBuf) {
-		throw CppSQLite3Exception(CPPSQLITE_ERROR, "Cannot allocate memory", DONT_DELETE_MSG);
-	}
+    if (!mpBuf)
+    {
+        throw CppSQLite3Exception(CPPSQLITE_ERROR,
+                                ALLOCATION_ERROR_MESSAGE,
+                                DONT_DELETE_MSG);
+    }
 
-	memcpy(mpBuf, pBuf, mnBufferLen);
-	mbEncoded = true;
+    memcpy(mpBuf, pBuf, mnBufferLen);
+    mbEncoded = true;
 }
 
 
-const unsigned char*
-CppSQLite3Binary::getEncoded()
+const unsigned char* CppSQLite3Binary::getEncoded()
 {
-	if (!mbEncoded) {
-		unsigned char* ptmp = (unsigned char*)malloc(mnBinaryLen);
-		memcpy(ptmp, mpBuf, mnBinaryLen);
-		mnEncodedLen = sqlite3_encode_binary(ptmp, mnBinaryLen, mpBuf);
-		free(ptmp);
-		mbEncoded = true;
-	}
+    if (!mbEncoded)
+    {
+        unsigned char* ptmp = (unsigned char*)malloc(mnBinaryLen);
+        memcpy(ptmp, mpBuf, mnBinaryLen);
+        mnEncodedLen = sqlite3_encode_binary(ptmp, mnBinaryLen, mpBuf);
+        free(ptmp);
+        mbEncoded = true;
+    }
 
-	return mpBuf;
+    return mpBuf;
 }
 
 
-const unsigned char*
-CppSQLite3Binary::getBinary()
+const unsigned char* CppSQLite3Binary::getBinary()
 {
-	if (mbEncoded) {
-		// in/out buffers can be the same
-		mnBinaryLen = sqlite3_decode_binary(mpBuf, mpBuf);
+    if (mbEncoded)
+    {
+        // in/out buffers can be the same
+        mnBinaryLen = sqlite3_decode_binary(mpBuf, mpBuf);
 
-		if (mnBinaryLen == -1) {
-			throw CppSQLite3Exception(CPPSQLITE_ERROR, "Cannot decode binary", DONT_DELETE_MSG);
-		}
+        if (mnBinaryLen == -1)
+        {
+            throw CppSQLite3Exception(CPPSQLITE_ERROR,
+                                    "Cannot decode binary",
+                                    DONT_DELETE_MSG);
+        }
 
-		mbEncoded = false;
-	}
+        mbEncoded = false;
+    }
 
-	return mpBuf;
+    return mpBuf;
 }
 
 
-int
-CppSQLite3Binary::getBinaryLength()
+int CppSQLite3Binary::getBinaryLength()
 {
-	getBinary();
-	return mnBinaryLen;
+    getBinary();
+    return mnBinaryLen;
 }
 
 
-unsigned char*
-CppSQLite3Binary::allocBuffer(int nLen)
+unsigned char* CppSQLite3Binary::allocBuffer(int nLen)
 {
-	clear();
+    clear();
 
-	// Allow extra space for encoded binary as per comments in
-	// SQLite encode.c See bottom of this file for implementation
-	// of SQLite functions use 3 instead of 2 just to be sure ;-)
-	mnBinaryLen = nLen;
-	mnBufferLen = 3 + (257 * nLen) / 254;
+    // Allow extra space for encoded binary as per comments in
+    // SQLite encode.c See bottom of this file for implementation
+    // of SQLite functions use 3 instead of 2 just to be sure ;-)
+    mnBinaryLen = nLen;
+    mnBufferLen = 3 + (257*nLen)/254;
 
-	mpBuf = (unsigned char*)malloc(mnBufferLen);
+    mpBuf = (unsigned char*)malloc(mnBufferLen);
 
-	if (!mpBuf) {
-		throw CppSQLite3Exception(CPPSQLITE_ERROR, "Cannot allocate memory", DONT_DELETE_MSG);
-	}
+    if (!mpBuf)
+    {
+        throw CppSQLite3Exception(CPPSQLITE_ERROR,
+                                ALLOCATION_ERROR_MESSAGE,
+                                DONT_DELETE_MSG);
+    }
 
-	mbEncoded = false;
+    mbEncoded = false;
 
-	return mpBuf;
+    return mpBuf;
 }
 
 
-void
-CppSQLite3Binary::clear()
+void CppSQLite3Binary::clear()
 {
-	if (mpBuf) {
-		mnBinaryLen = 0;
-		mnBufferLen = 0;
-		free(mpBuf);
-		mpBuf = 0;
-	}
+    if (mpBuf)
+    {
+        mnBinaryLen = 0;
+        mnBufferLen = 0;
+        free(mpBuf);
+        mpBuf = 0;
+    }
 }
+
 
 ////////////////////////////////////////////////////////////////////////////////
 
 CppSQLite3Query::CppSQLite3Query()
 {
-	mpVM = 0;
-	mbEof = true;
-	mnCols = 0;
-	mbOwnVM = false;
+    mpVM = 0;
+    mbEof = true;
+    mnCols = 0;
+    mbOwnVM = false;
 }
+
 
 CppSQLite3Query::CppSQLite3Query(const CppSQLite3Query& rQuery)
 {
-	mpVM = rQuery.mpVM;
-	// Only one object can own the VM
-	const_cast<CppSQLite3Query&>(rQuery).mpVM = 0;
-	mbEof = rQuery.mbEof;
-	mnCols = rQuery.mnCols;
-	mbOwnVM = rQuery.mbOwnVM;
+    mpVM = rQuery.mpVM;
+    // Only one object can own the VM
+    const_cast<CppSQLite3Query&>(rQuery).mpVM = 0;
+    mbEof = rQuery.mbEof;
+    mnCols = rQuery.mnCols;
+    mbOwnVM = rQuery.mbOwnVM;
 }
 
 
-CppSQLite3Query::CppSQLite3Query(sqlite3* pDB, sqlite3_stmt* pVM, bool bEof, bool bOwnVM /*=true*/)
+CppSQLite3Query::CppSQLite3Query(sqlite3* pDB,
+                            sqlite3_stmt* pVM,
+                            bool bEof,
+                            bool bOwnVM/*=true*/)
 {
-	mpDB = pDB;
-	mpVM = pVM;
-	mbEof = bEof;
-	mnCols = sqlite3_column_count(mpVM);
-	mbOwnVM = bOwnVM;
+    mpDB = pDB;
+    mpVM = pVM;
+    mbEof = bEof;
+    mnCols = sqlite3_column_count(mpVM);
+    mbOwnVM = bOwnVM;
 }
+
 
 CppSQLite3Query::~CppSQLite3Query()
 {
-	try {
-		finalize();
-	} catch (...) {
-	}
+    try
+    {
+        finalize();
+    }
+    catch (...)
+    {
+    }
 }
 
 
-CppSQLite3Query&
-CppSQLite3Query::operator=(const CppSQLite3Query& rQuery)
+CppSQLite3Query& CppSQLite3Query::operator=(const CppSQLite3Query& rQuery)
 {
-	try {
-		finalize();
-	} catch (...) {
-	}
-	mpVM = rQuery.mpVM;
-	// Only one object can own the VM
-	const_cast<CppSQLite3Query&>(rQuery).mpVM = 0;
-	mbEof = rQuery.mbEof;
-	mnCols = rQuery.mnCols;
-	mbOwnVM = rQuery.mbOwnVM;
-	return *this;
+    try
+    {
+        finalize();
+    }
+    catch (...)
+    {
+    }
+    mpVM = rQuery.mpVM;
+    // Only one object can own the VM
+    const_cast<CppSQLite3Query&>(rQuery).mpVM = 0;
+    mbEof = rQuery.mbEof;
+    mnCols = rQuery.mnCols;
+    mbOwnVM = rQuery.mbOwnVM;
+    return *this;
 }
 
 
-int
-CppSQLite3Query::numFields()
+int CppSQLite3Query::numFields() const
 {
-	checkVM();
-	return mnCols;
+    checkVM();
+    return mnCols;
 }
 
 
-const char*
-CppSQLite3Query::fieldValue(int nField)
+const char* CppSQLite3Query::fieldValue(int nField) const
 {
-	checkVM();
+    checkVM();
 
-	if (nField < 0 || nField > mnCols - 1) {
-		throw CppSQLite3Exception(
-			CPPSQLITE_ERROR, "Invalid field index requested", DONT_DELETE_MSG);
-	}
+    if (nField < 0 || nField > mnCols-1)
+    {
+        throw CppSQLite3Exception(CPPSQLITE_ERROR,
+                                "Invalid field index requested",
+                                DONT_DELETE_MSG);
+    }
 
-	return (const char*)sqlite3_column_text(mpVM, nField);
+    return (const char*)sqlite3_column_text(mpVM, nField);
 }
 
 
-const char*
-CppSQLite3Query::fieldValue(const char* szField)
+const char* CppSQLite3Query::fieldValue(const char* szField) const
 {
-	int nField = fieldIndex(szField);
-	return (const char*)sqlite3_column_text(mpVM, nField);
+    int nField = fieldIndex(szField);
+    return (const char*)sqlite3_column_text(mpVM, nField);
 }
 
 
-int
-CppSQLite3Query::getIntField(int nField, int nNullValue /*=0*/)
+int CppSQLite3Query::getIntField(int nField, int nNullValue/*=0*/) const
 {
-	if (fieldDataType(nField) == SQLITE_NULL) {
-		return nNullValue;
-	} else {
-		return sqlite3_column_int(mpVM, nField);
-	}
+    if (fieldDataType(nField) == SQLITE_NULL)
+    {
+        return nNullValue;
+    }
+    else
+    {
+        return sqlite3_column_int(mpVM, nField);
+    }
 }
 
 
-int
-CppSQLite3Query::getIntField(const char* szField, int nNullValue /*=0*/)
+int CppSQLite3Query::getIntField(const char* szField, int nNullValue/*=0*/) const
 {
-	int nField = fieldIndex(szField);
-	return getIntField(nField, nNullValue);
+    int nField = fieldIndex(szField);
+    return getIntField(nField, nNullValue);
 }
 
 
-sqlite_int64
-CppSQLite3Query::getInt64Field(int nField, sqlite_int64 nNullValue /*=0*/)
+long long CppSQLite3Query::getInt64Field(int nField, long long nNullValue/*=0*/) const
 {
-	if (fieldDataType(nField) == SQLITE_NULL) {
-		return nNullValue;
-	} else {
-		return sqlite3_column_int64(mpVM, nField);
-	}
+    if (fieldDataType(nField) == SQLITE_NULL)
+    {
+        return nNullValue;
+    }
+    else
+    {
+        return sqlite3_column_int64(mpVM, nField);
+    }
 }
 
 
-sqlite_int64
-CppSQLite3Query::getInt64Field(const char* szField, sqlite_int64 nNullValue /*=0*/)
+long long CppSQLite3Query::getInt64Field(const char* szField, long long nNullValue/*=0*/) const
 {
-	int nField = fieldIndex(szField);
-	return getInt64Field(nField, nNullValue);
+    int nField = fieldIndex(szField);
+    return getInt64Field(nField, nNullValue);
 }
 
 
-double
-CppSQLite3Query::getFloatField(int nField, double fNullValue /*=0.0*/)
+float CppSQLite3Query::getFloatField(int nField, float fNullValue/*=0.0f*/) const
 {
-	if (fieldDataType(nField) == SQLITE_NULL) {
-		return fNullValue;
-	} else {
-		return sqlite3_column_double(mpVM, nField);
-	}
+    if (fieldDataType(nField) == SQLITE_NULL)
+    {
+        return fNullValue;
+    }
+    else
+    {
+        return static_cast<float>(sqlite3_column_double(mpVM, nField));
+    }
 }
 
 
-double
-CppSQLite3Query::getFloatField(const char* szField, double fNullValue /*=0.0*/)
+float CppSQLite3Query::getFloatField(const char* szField, float fNullValue/*=0.0f*/) const
 {
-	int nField = fieldIndex(szField);
-	return getFloatField(nField, fNullValue);
+    int nField = fieldIndex(szField);
+    return getFloatField(nField, fNullValue);
 }
 
 
-const char*
-CppSQLite3Query::getStringField(int nField, const char* szNullValue /*=""*/)
+double CppSQLite3Query::getDoubleField(int nField, double dNullValue/*=0.0*/) const
 {
-	if (fieldDataType(nField) == SQLITE_NULL) {
-		return szNullValue;
-	} else {
-		return (const char*)sqlite3_column_text(mpVM, nField);
-	}
+    if (fieldDataType(nField) == SQLITE_NULL)
+    {
+        return dNullValue;
+    }
+    else
+    {
+        return sqlite3_column_double(mpVM, nField);
+    }
 }
 
 
-const char*
-CppSQLite3Query::getStringField(const char* szField, const char* szNullValue /*=""*/)
+double CppSQLite3Query::getDoubleField(const char* szField, double dNullValue/*=0.0*/) const
 {
-	int nField = fieldIndex(szField);
-	return getStringField(nField, szNullValue);
+    int nField = fieldIndex(szField);
+    return getDoubleField(nField, dNullValue);
 }
 
 
-const unsigned char*
-CppSQLite3Query::getBlobField(int nField, int& nLen)
+const char* CppSQLite3Query::getStringField(int nField, const char* szNullValue/*=""*/) const
 {
-	checkVM();
-
-	if (nField < 0 || nField > mnCols - 1) {
-		throw CppSQLite3Exception(
-			CPPSQLITE_ERROR, "Invalid field index requested", DONT_DELETE_MSG);
-	}
-
-	nLen = sqlite3_column_bytes(mpVM, nField);
-	return (const unsigned char*)sqlite3_column_blob(mpVM, nField);
+    if (fieldDataType(nField) == SQLITE_NULL)
+    {
+        return szNullValue;
+    }
+    else
+    {
+        return (const char*)sqlite3_column_text(mpVM, nField);
+    }
 }
 
 
-const unsigned char*
-CppSQLite3Query::getBlobField(const char* szField, int& nLen)
+const char* CppSQLite3Query::getStringField(const char* szField, const char* szNullValue/*=""*/) const
 {
-	int nField = fieldIndex(szField);
-	return getBlobField(nField, nLen);
+    int nField = fieldIndex(szField);
+    return getStringField(nField, szNullValue);
 }
 
 
-bool
-CppSQLite3Query::fieldIsNull(int nField)
+const unsigned char* CppSQLite3Query::getBlobField(int nField, int& nLen) const
 {
-	return (fieldDataType(nField) == SQLITE_NULL);
+    checkVM();
+
+    if (nField < 0 || nField > mnCols-1)
+    {
+        throw CppSQLite3Exception(CPPSQLITE_ERROR,
+                                "Invalid field index requested",
+                                DONT_DELETE_MSG);
+    }
+
+    nLen = sqlite3_column_bytes(mpVM, nField);
+    return (const unsigned char*)sqlite3_column_blob(mpVM, nField);
 }
 
 
-bool
-CppSQLite3Query::fieldIsNull(const char* szField)
+const unsigned char* CppSQLite3Query::getBlobField(const char* szField, int& nLen) const
 {
-	int nField = fieldIndex(szField);
-	return (fieldDataType(nField) == SQLITE_NULL);
+    int nField = fieldIndex(szField);
+    return getBlobField(nField, nLen);
 }
 
 
-int
-CppSQLite3Query::fieldIndex(const char* szField)
+bool CppSQLite3Query::fieldIsNull(int nField) const
 {
-	checkVM();
-
-	if (szField) {
-		for (int nField = 0; nField < mnCols; nField++) {
-			const char* szTemp = sqlite3_column_name(mpVM, nField);
-
-			if (strcmp(szField, szTemp) == 0) {
-				return nField;
-			}
-		}
-	}
-
-	throw CppSQLite3Exception(CPPSQLITE_ERROR, "Invalid field name requested", DONT_DELETE_MSG);
+    return (fieldDataType(nField) == SQLITE_NULL);
 }
 
 
-const char*
-CppSQLite3Query::fieldName(int nCol)
+bool CppSQLite3Query::fieldIsNull(const char* szField) const
 {
-	checkVM();
-
-	if (nCol < 0 || nCol > mnCols - 1) {
-		throw CppSQLite3Exception(
-			CPPSQLITE_ERROR, "Invalid field index requested", DONT_DELETE_MSG);
-	}
-
-	return sqlite3_column_name(mpVM, nCol);
+    int nField = fieldIndex(szField);
+    return (fieldDataType(nField) == SQLITE_NULL);
 }
 
 
-const char*
-CppSQLite3Query::fieldDeclType(int nCol)
+int CppSQLite3Query::fieldIndex(const char* szField) const
 {
-	checkVM();
+    checkVM();
 
-	if (nCol < 0 || nCol > mnCols - 1) {
-		throw CppSQLite3Exception(
-			CPPSQLITE_ERROR, "Invalid field index requested", DONT_DELETE_MSG);
-	}
+    if (szField)
+    {
+        for (int nField = 0; nField < mnCols; nField++)
+        {
+            const char* szTemp = sqlite3_column_name(mpVM, nField);
 
-	return sqlite3_column_decltype(mpVM, nCol);
+            if (strcmp(szField, szTemp) == 0)
+            {
+                return nField;
+            }
+        }
+    }
+
+    throw CppSQLite3Exception(CPPSQLITE_ERROR,
+                            "Invalid field name requested",
+                            DONT_DELETE_MSG);
 }
 
 
-int
-CppSQLite3Query::fieldDataType(int nCol)
+const char* CppSQLite3Query::fieldName(int nCol) const
 {
-	checkVM();
+    checkVM();
 
-	if (nCol < 0 || nCol > mnCols - 1) {
-		throw CppSQLite3Exception(
-			CPPSQLITE_ERROR, "Invalid field index requested", DONT_DELETE_MSG);
-	}
+    if (nCol < 0 || nCol > mnCols-1)
+    {
+        throw CppSQLite3Exception(CPPSQLITE_ERROR,
+                                "Invalid field index requested",
+                                DONT_DELETE_MSG);
+    }
 
-	return sqlite3_column_type(mpVM, nCol);
+    return sqlite3_column_name(mpVM, nCol);
 }
 
 
-bool
-CppSQLite3Query::eof()
+const char* CppSQLite3Query::fieldDeclType(int nCol) const
 {
-	checkVM();
-	return mbEof;
+    checkVM();
+
+    if (nCol < 0 || nCol > mnCols-1)
+    {
+        throw CppSQLite3Exception(CPPSQLITE_ERROR,
+                                "Invalid field index requested",
+                                DONT_DELETE_MSG);
+    }
+
+    return sqlite3_column_decltype(mpVM, nCol);
 }
 
 
-void
-CppSQLite3Query::nextRow()
+int CppSQLite3Query::fieldDataType(int nCol) const
 {
-	checkVM();
+    checkVM();
 
-	int nRet = sqlite3_step(mpVM);
+    if (nCol < 0 || nCol > mnCols-1)
+    {
+        throw CppSQLite3Exception(CPPSQLITE_ERROR,
+                                "Invalid field index requested",
+                                DONT_DELETE_MSG);
+    }
 
-	if (nRet == SQLITE_DONE) {
-		// no rows
-		mbEof = true;
-	} else if (nRet == SQLITE_ROW) {
-		// more rows, nothing to do
-	} else {
-		nRet = sqlite3_finalize(mpVM);
-		mpVM = 0;
-		const char* szError = sqlite3_errmsg(mpDB);
-		throw CppSQLite3Exception(nRet, (char*)szError, DONT_DELETE_MSG);
-	}
+    return sqlite3_column_type(mpVM, nCol);
 }
 
 
-void
-CppSQLite3Query::finalize()
+bool CppSQLite3Query::eof() const
 {
-	if (mpVM && mbOwnVM) {
-		int nRet = sqlite3_finalize(mpVM);
-		mpVM = 0;
-		if (nRet != SQLITE_OK) {
-			const char* szError = sqlite3_errmsg(mpDB);
-			throw CppSQLite3Exception(nRet, (char*)szError, DONT_DELETE_MSG);
-		}
-	}
+    checkVM();
+    return mbEof;
 }
 
 
-void
-CppSQLite3Query::checkVM()
+void CppSQLite3Query::nextRow()
 {
-	if (mpVM == 0) {
-		throw CppSQLite3Exception(CPPSQLITE_ERROR, "Null Virtual Machine pointer", DONT_DELETE_MSG);
-	}
+    checkVM();
+
+    int nRet = sqlite3_step(mpVM);
+
+    if (nRet == SQLITE_DONE)
+    {
+        // no rows
+        mbEof = true;
+    }
+    else if (nRet == SQLITE_ROW)
+    {
+        // more rows, nothing to do
+    }
+    else
+    {
+        nRet = sqlite3_finalize(mpVM);
+        mpVM = 0;
+        const char* szError = sqlite3_errmsg(mpDB);
+        throw CppSQLite3Exception(nRet,
+                                (char*)szError,
+                                DONT_DELETE_MSG);
+    }
 }
+
+
+void CppSQLite3Query::finalize()
+{
+    if (mpVM && mbOwnVM)
+    {
+        int nRet = sqlite3_finalize(mpVM);
+        mpVM = 0;
+        if (nRet != SQLITE_OK)
+        {
+            const char* szError = sqlite3_errmsg(mpDB);
+            throw CppSQLite3Exception(nRet, (char*)szError, DONT_DELETE_MSG);
+        }
+    }
+}
+
+
+void CppSQLite3Query::checkVM() const
+{
+    if (mpVM == 0)
+    {
+        throw CppSQLite3Exception(CPPSQLITE_ERROR,
+                                "Null Virtual Machine pointer",
+                                DONT_DELETE_MSG);
+    }
+}
+
 
 ////////////////////////////////////////////////////////////////////////////////
 
 CppSQLite3Table::CppSQLite3Table()
 {
-	mpaszResults = 0;
-	mnRows = 0;
-	mnCols = 0;
-	mnCurrentRow = 0;
+    mpaszResults = 0;
+    mnRows = 0;
+    mnCols = 0;
+    mnCurrentRow = 0;
 }
+
 
 CppSQLite3Table::CppSQLite3Table(const CppSQLite3Table& rTable)
 {
-	mpaszResults = rTable.mpaszResults;
-	// Only one object can own the results
-	const_cast<CppSQLite3Table&>(rTable).mpaszResults = 0;
-	mnRows = rTable.mnRows;
-	mnCols = rTable.mnCols;
-	mnCurrentRow = rTable.mnCurrentRow;
+    mpaszResults = rTable.mpaszResults;
+    // Only one object can own the results
+    const_cast<CppSQLite3Table&>(rTable).mpaszResults = 0;
+    mnRows = rTable.mnRows;
+    mnCols = rTable.mnCols;
+    mnCurrentRow = rTable.mnCurrentRow;
 }
+
 
 CppSQLite3Table::CppSQLite3Table(char** paszResults, int nRows, int nCols)
 {
-	mpaszResults = paszResults;
-	mnRows = nRows;
-	mnCols = nCols;
-	mnCurrentRow = 0;
+    mpaszResults = paszResults;
+    mnRows = nRows;
+    mnCols = nCols;
+    mnCurrentRow = 0;
 }
+
 
 CppSQLite3Table::~CppSQLite3Table()
 {
-	try {
-		finalize();
-	} catch (...) {
-	}
+    try
+    {
+        finalize();
+    }
+    catch (...)
+    {
+    }
 }
 
 
-CppSQLite3Table&
-CppSQLite3Table::operator=(const CppSQLite3Table& rTable)
+CppSQLite3Table& CppSQLite3Table::operator=(const CppSQLite3Table& rTable)
 {
-	try {
-		finalize();
-	} catch (...) {
-	}
-	mpaszResults = rTable.mpaszResults;
-	// Only one object can own the results
-	const_cast<CppSQLite3Table&>(rTable).mpaszResults = 0;
-	mnRows = rTable.mnRows;
-	mnCols = rTable.mnCols;
-	mnCurrentRow = rTable.mnCurrentRow;
-	return *this;
+    try
+    {
+        finalize();
+    }
+    catch (...)
+    {
+    }
+    mpaszResults = rTable.mpaszResults;
+    // Only one object can own the results
+    const_cast<CppSQLite3Table&>(rTable).mpaszResults = 0;
+    mnRows = rTable.mnRows;
+    mnCols = rTable.mnCols;
+    mnCurrentRow = rTable.mnCurrentRow;
+    return *this;
 }
 
 
-void
-CppSQLite3Table::finalize()
+void CppSQLite3Table::finalize()
 {
-	if (mpaszResults) {
-		sqlite3_free_table(mpaszResults);
-		mpaszResults = 0;
-	}
+    if (mpaszResults)
+    {
+        sqlite3_free_table(mpaszResults);
+        mpaszResults = 0;
+    }
 }
 
 
-int
-CppSQLite3Table::numFields()
+int CppSQLite3Table::numFields() const
 {
-	checkResults();
-	return mnCols;
+    checkResults();
+    return mnCols;
 }
 
 
-int
-CppSQLite3Table::numRows()
+int CppSQLite3Table::numRows() const
 {
-	checkResults();
-	return mnRows;
+    checkResults();
+    return mnRows;
 }
 
 
-const char*
-CppSQLite3Table::fieldValue(int nField)
+const char* CppSQLite3Table::fieldValue(int nField) const
 {
-	checkResults();
+    checkResults();
 
-	if (nField < 0 || nField > mnCols - 1) {
-		throw CppSQLite3Exception(
-			CPPSQLITE_ERROR, "Invalid field index requested", DONT_DELETE_MSG);
-	}
+    if (nField < 0 || nField > mnCols-1)
+    {
+        throw CppSQLite3Exception(CPPSQLITE_ERROR,
+                                "Invalid field index requested",
+                                DONT_DELETE_MSG);
+    }
 
-	int nIndex = (mnCurrentRow * mnCols) + mnCols + nField;
-	return mpaszResults[nIndex];
+    int nIndex = (mnCurrentRow*mnCols) + mnCols + nField;
+    return mpaszResults[nIndex];
 }
 
 
-const char*
-CppSQLite3Table::fieldValue(const char* szField)
+const char* CppSQLite3Table::fieldValue(const char* szField) const
 {
-	checkResults();
+    checkResults();
 
-	if (szField) {
-		for (int nField = 0; nField < mnCols; nField++) {
-			if (strcmp(szField, mpaszResults[nField]) == 0) {
-				int nIndex = (mnCurrentRow * mnCols) + mnCols + nField;
-				return mpaszResults[nIndex];
-			}
-		}
-	}
+    if (szField)
+    {
+        for (int nField = 0; nField < mnCols; nField++)
+        {
+            if (strcmp(szField, mpaszResults[nField]) == 0)
+            {
+                int nIndex = (mnCurrentRow*mnCols) + mnCols + nField;
+                return mpaszResults[nIndex];
+            }
+        }
+    }
 
-	throw CppSQLite3Exception(CPPSQLITE_ERROR, "Invalid field name requested", DONT_DELETE_MSG);
+    throw CppSQLite3Exception(CPPSQLITE_ERROR,
+                            "Invalid field name requested",
+                            DONT_DELETE_MSG);
 }
 
 
-int
-CppSQLite3Table::getIntField(int nField, int nNullValue /*=0*/)
+int CppSQLite3Table::getIntField(int nField, int nNullValue/*=0*/) const
 {
-	if (fieldIsNull(nField)) {
-		return nNullValue;
-	} else {
-		return atoi(fieldValue(nField));
-	}
+    if (fieldIsNull(nField))
+    {
+        return nNullValue;
+    }
+    else
+    {
+        return atoi(fieldValue(nField));
+    }
 }
 
 
-int
-CppSQLite3Table::getIntField(const char* szField, int nNullValue /*=0*/)
+int CppSQLite3Table::getIntField(const char* szField, int nNullValue/*=0*/) const
 {
-	if (fieldIsNull(szField)) {
-		return nNullValue;
-	} else {
-		return atoi(fieldValue(szField));
-	}
+    if (fieldIsNull(szField))
+    {
+        return nNullValue;
+    }
+    else
+    {
+        return atoi(fieldValue(szField));
+    }
 }
 
 
-double
-CppSQLite3Table::getFloatField(int nField, double fNullValue /*=0.0*/)
+float CppSQLite3Table::getFloatField(int nField, float fNullValue/*=0.0f*/) const
 {
-	if (fieldIsNull(nField)) {
-		return fNullValue;
-	} else {
-		return atof(fieldValue(nField));
-	}
+    if (fieldIsNull(nField))
+    {
+        return fNullValue;
+    }
+    else
+    {
+        return static_cast<float>(atof(fieldValue(nField)));
+    }
 }
 
 
-double
-CppSQLite3Table::getFloatField(const char* szField, double fNullValue /*=0.0*/)
+float CppSQLite3Table::getFloatField(const char* szField, float fNullValue/*=0.0f*/) const
 {
-	if (fieldIsNull(szField)) {
-		return fNullValue;
-	} else {
-		return atof(fieldValue(szField));
-	}
+    if (fieldIsNull(szField))
+    {
+        return fNullValue;
+    }
+    else
+    {
+        return static_cast<float>(atof(fieldValue(szField)));
+    }
 }
 
 
-const char*
-CppSQLite3Table::getStringField(int nField, const char* szNullValue /*=""*/)
+double CppSQLite3Table::getDoubleField(int nField, double dNullValue/*=0.0*/) const
 {
-	if (fieldIsNull(nField)) {
-		return szNullValue;
-	} else {
-		return fieldValue(nField);
-	}
+    if (fieldIsNull(nField))
+    {
+        return dNullValue;
+    }
+    else
+    {
+        return atof(fieldValue(nField));
+    }
 }
 
 
-const char*
-CppSQLite3Table::getStringField(const char* szField, const char* szNullValue /*=""*/)
+double CppSQLite3Table::getDoubleField(const char* szField, double dNullValue/*=0.0*/) const
 {
-	if (fieldIsNull(szField)) {
-		return szNullValue;
-	} else {
-		return fieldValue(szField);
-	}
+    if (fieldIsNull(szField))
+    {
+        return dNullValue;
+    }
+    else
+    {
+        return atof(fieldValue(szField));
+    }
 }
 
 
-bool
-CppSQLite3Table::fieldIsNull(int nField)
+const char* CppSQLite3Table::getStringField(int nField, const char* szNullValue/*=""*/) const
 {
-	checkResults();
-	return (fieldValue(nField) == 0);
+    if (fieldIsNull(nField))
+    {
+        return szNullValue;
+    }
+    else
+    {
+        return fieldValue(nField);
+    }
 }
 
 
-bool
-CppSQLite3Table::fieldIsNull(const char* szField)
+const char* CppSQLite3Table::getStringField(const char* szField, const char* szNullValue/*=""*/) const
 {
-	checkResults();
-	return (fieldValue(szField) == 0);
+    if (fieldIsNull(szField))
+    {
+        return szNullValue;
+    }
+    else
+    {
+        return fieldValue(szField);
+    }
 }
 
 
-const char*
-CppSQLite3Table::fieldName(int nCol)
+bool CppSQLite3Table::fieldIsNull(int nField) const
 {
-	checkResults();
-
-	if (nCol < 0 || nCol > mnCols - 1) {
-		throw CppSQLite3Exception(
-			CPPSQLITE_ERROR, "Invalid field index requested", DONT_DELETE_MSG);
-	}
-
-	return mpaszResults[nCol];
+    checkResults();
+    return (fieldValue(nField) == 0);
 }
 
 
-void
-CppSQLite3Table::setRow(int nRow)
+bool CppSQLite3Table::fieldIsNull(const char* szField) const
 {
-	checkResults();
-
-	if (nRow < 0 || nRow > mnRows - 1) {
-		throw CppSQLite3Exception(CPPSQLITE_ERROR, "Invalid row index requested", DONT_DELETE_MSG);
-	}
-
-	mnCurrentRow = nRow;
+    checkResults();
+    return (fieldValue(szField) == 0);
 }
 
 
-void
-CppSQLite3Table::checkResults()
+const char* CppSQLite3Table::fieldName(int nCol) const
 {
-	if (mpaszResults == 0) {
-		throw CppSQLite3Exception(CPPSQLITE_ERROR, "Null Results pointer", DONT_DELETE_MSG);
-	}
+    checkResults();
+
+    if (nCol < 0 || nCol > mnCols-1)
+    {
+        throw CppSQLite3Exception(CPPSQLITE_ERROR,
+                                "Invalid field index requested",
+                                DONT_DELETE_MSG);
+    }
+
+    return mpaszResults[nCol];
 }
+
+
+void CppSQLite3Table::setRow(int nRow)
+{
+    checkResults();
+
+    if (nRow < 0 || nRow > mnRows-1)
+    {
+        throw CppSQLite3Exception(CPPSQLITE_ERROR,
+                                "Invalid row index requested",
+                                DONT_DELETE_MSG);
+    }
+
+    mnCurrentRow = nRow;
+}
+
+
+void CppSQLite3Table::checkResults() const
+{
+    if (mpaszResults == 0)
+    {
+        throw CppSQLite3Exception(CPPSQLITE_ERROR,
+                                "Null Results pointer",
+                                DONT_DELETE_MSG);
+    }
+}
+
 
 ////////////////////////////////////////////////////////////////////////////////
 
 CppSQLite3Statement::CppSQLite3Statement()
 {
-	mpDB = 0;
-	mpVM = 0;
+    mpDB = 0;
+    mpVM = 0;
 }
+
 
 CppSQLite3Statement::CppSQLite3Statement(const CppSQLite3Statement& rStatement)
 {
-	mpDB = rStatement.mpDB;
-	mpVM = rStatement.mpVM;
-	// Only one object can own VM
-	const_cast<CppSQLite3Statement&>(rStatement).mpVM = 0;
+    mpDB = rStatement.mpDB;
+    mpVM = rStatement.mpVM;
+    // Only one object can own VM
+    const_cast<CppSQLite3Statement&>(rStatement).mpVM = 0;
 }
+
 
 CppSQLite3Statement::CppSQLite3Statement(sqlite3* pDB, sqlite3_stmt* pVM)
 {
-	mpDB = pDB;
-	mpVM = pVM;
+    mpDB = pDB;
+    mpVM = pVM;
 }
+
 
 CppSQLite3Statement::~CppSQLite3Statement()
 {
-	try {
-		finalize();
-	} catch (...) {
-	}
+    try
+    {
+        finalize();
+    }
+    catch (...)
+    {
+    }
 }
 
 
-CppSQLite3Statement&
-CppSQLite3Statement::operator=(const CppSQLite3Statement& rStatement)
+CppSQLite3Statement& CppSQLite3Statement::operator=(const CppSQLite3Statement& rStatement)
 {
-	mpDB = rStatement.mpDB;
-	mpVM = rStatement.mpVM;
-	// Only one object can own VM
-	const_cast<CppSQLite3Statement&>(rStatement).mpVM = 0;
-	return *this;
+    mpDB = rStatement.mpDB;
+    mpVM = rStatement.mpVM;
+    // Only one object can own VM
+    const_cast<CppSQLite3Statement&>(rStatement).mpVM = 0;
+    return *this;
 }
 
 
-int
-CppSQLite3Statement::execDML()
+int CppSQLite3Statement::execDML()
 {
-	checkDB();
-	checkVM();
+    checkDB();
+    checkVM();
 
-	const char* szError = 0;
+    const char* szError=0;
 
-	int nRet = sqlite3_step(mpVM);
+    int nRet = sqlite3_step(mpVM);
 
-	if (nRet == SQLITE_DONE) {
-		int nRowsChanged = sqlite3_changes(mpDB);
+    if (nRet == SQLITE_DONE)
+    {
+        int nRowsChanged = sqlite3_changes(mpDB);
 
-		nRet = sqlite3_reset(mpVM);
+        nRet = sqlite3_reset(mpVM);
 
-		if (nRet != SQLITE_OK) {
-			szError = sqlite3_errmsg(mpDB);
-			throw CppSQLite3Exception(nRet, (char*)szError, DONT_DELETE_MSG);
-		}
+        if (nRet != SQLITE_OK)
+        {
+            szError = sqlite3_errmsg(mpDB);
+            throw CppSQLite3Exception(nRet, (char*)szError, DONT_DELETE_MSG);
+        }
 
-		return nRowsChanged;
-	} else {
-		nRet = sqlite3_reset(mpVM);
-		szError = sqlite3_errmsg(mpDB);
-		throw CppSQLite3Exception(nRet, (char*)szError, DONT_DELETE_MSG);
-	}
+        return nRowsChanged;
+    }
+    else
+    {
+        nRet = sqlite3_reset(mpVM);
+        szError = sqlite3_errmsg(mpDB);
+        throw CppSQLite3Exception(nRet, (char*)szError, DONT_DELETE_MSG);
+    }
 }
 
 
-CppSQLite3Query
-CppSQLite3Statement::execQuery()
+CppSQLite3Query CppSQLite3Statement::execQuery()
 {
-	checkDB();
-	checkVM();
+    checkDB();
+    checkVM();
 
-	int nRet = sqlite3_step(mpVM);
+    int nRet = sqlite3_step(mpVM);
 
-	if (nRet == SQLITE_DONE) {
-		// no rows
-		return CppSQLite3Query(mpDB, mpVM, true /*eof*/, false);
-	} else if (nRet == SQLITE_ROW) {
-		// at least 1 row
-		return CppSQLite3Query(mpDB, mpVM, false /*eof*/, false);
-	} else {
-		nRet = sqlite3_reset(mpVM);
-		const char* szError = sqlite3_errmsg(mpDB);
-		throw CppSQLite3Exception(nRet, (char*)szError, DONT_DELETE_MSG);
-	}
+    if (nRet == SQLITE_DONE)
+    {
+        // no rows
+        return CppSQLite3Query(mpDB, mpVM, true/*eof*/, false);
+    }
+    else if (nRet == SQLITE_ROW)
+    {
+        // at least 1 row
+        return CppSQLite3Query(mpDB, mpVM, false/*eof*/, false);
+    }
+    else
+    {
+        nRet = sqlite3_reset(mpVM);
+        const char* szError = sqlite3_errmsg(mpDB);
+        throw CppSQLite3Exception(nRet, (char*)szError, DONT_DELETE_MSG);
+    }
 }
 
 
-void
-CppSQLite3Statement::bind(int nParam, const char* szValue)
+void CppSQLite3Statement::bind(int nParam, const char* szValue)
 {
-	checkVM();
-	int nRes = sqlite3_bind_text(mpVM, nParam, szValue, -1, SQLITE_TRANSIENT);
+    checkVM();
+    int nRes = sqlite3_bind_text(mpVM, nParam, szValue, -1, SQLITE_TRANSIENT);
 
-	if (nRes != SQLITE_OK) {
-		throw CppSQLite3Exception(nRes, "Error binding string param", DONT_DELETE_MSG);
-	}
+    if (nRes != SQLITE_OK)
+    {
+        throw CppSQLite3Exception(nRes,
+                                "Error binding string param",
+                                DONT_DELETE_MSG);
+    }
 }
 
 
-void
-CppSQLite3Statement::bind(int nParam, const int nValue)
+void CppSQLite3Statement::bind(int nParam, const int nValue)
 {
-	checkVM();
-	int nRes = sqlite3_bind_int(mpVM, nParam, nValue);
+    checkVM();
+    int nRes = sqlite3_bind_int(mpVM, nParam, nValue);
 
-	if (nRes != SQLITE_OK) {
-		throw CppSQLite3Exception(nRes, "Error binding int param", DONT_DELETE_MSG);
-	}
+    if (nRes != SQLITE_OK)
+    {
+        throw CppSQLite3Exception(nRes,
+                                "Error binding int param",
+                                DONT_DELETE_MSG);
+    }
 }
 
 
-void
-CppSQLite3Statement::bind(int nParam, const double dValue)
+void CppSQLite3Statement::bind(int nParam, const long long nValue)
 {
-	checkVM();
-	int nRes = sqlite3_bind_double(mpVM, nParam, dValue);
+    checkVM();
+    int nRes = sqlite3_bind_int64(mpVM, nParam, nValue);
 
-	if (nRes != SQLITE_OK) {
-		throw CppSQLite3Exception(nRes, "Error binding double param", DONT_DELETE_MSG);
-	}
+    if (nRes != SQLITE_OK)
+    {
+        throw CppSQLite3Exception(nRes,
+                                  "Error binding int64 param",
+                                  DONT_DELETE_MSG);
+    }
 }
 
 
-void
-CppSQLite3Statement::bind(int nParam, const unsigned char* blobValue, int nLen)
+void CppSQLite3Statement::bind(int nParam, const double dValue)
 {
-	checkVM();
-	int nRes = sqlite3_bind_blob(mpVM, nParam, (const void*)blobValue, nLen, SQLITE_TRANSIENT);
+    checkVM();
+    int nRes = sqlite3_bind_double(mpVM, nParam, dValue);
 
-	if (nRes != SQLITE_OK) {
-		throw CppSQLite3Exception(nRes, "Error binding blob param", DONT_DELETE_MSG);
-	}
+    if (nRes != SQLITE_OK)
+    {
+        throw CppSQLite3Exception(nRes,
+                                "Error binding double param",
+                                DONT_DELETE_MSG);
+    }
 }
 
 
-void
-CppSQLite3Statement::bindNull(int nParam)
+void CppSQLite3Statement::bind(int nParam, const unsigned char* blobValue, int nLen)
 {
-	checkVM();
-	int nRes = sqlite3_bind_null(mpVM, nParam);
+    checkVM();
+    int nRes = sqlite3_bind_blob(mpVM, nParam,
+                                (const void*)blobValue, nLen, SQLITE_TRANSIENT);
 
-	if (nRes != SQLITE_OK) {
-		throw CppSQLite3Exception(nRes, "Error binding NULL param", DONT_DELETE_MSG);
-	}
+    if (nRes != SQLITE_OK)
+    {
+        throw CppSQLite3Exception(nRes,
+                                "Error binding blob param",
+                                DONT_DELETE_MSG);
+    }
 }
 
 
-int
-CppSQLite3Statement::bindParameterIndex(const char* szParam)
+void CppSQLite3Statement::bindNull(int nParam)
 {
-	checkVM();
+    checkVM();
+    int nRes = sqlite3_bind_null(mpVM, nParam);
 
-	int nParam = sqlite3_bind_parameter_index(mpVM, szParam);
-
-	int nn = sqlite3_bind_parameter_count(mpVM);
-	const char* sz1 = sqlite3_bind_parameter_name(mpVM, 1);
-	const char* sz2 = sqlite3_bind_parameter_name(mpVM, 2);
-
-	if (!nParam) {
-		char buf[128];
-		sprintf(buf, "Parameter '%s' is not valid for this statement", szParam);
-		throw CppSQLite3Exception(CPPSQLITE_ERROR, buf, DONT_DELETE_MSG);
-	}
-
-	return nParam;
+    if (nRes != SQLITE_OK)
+    {
+        throw CppSQLite3Exception(nRes,
+                                "Error binding NULL param",
+                                DONT_DELETE_MSG);
+    }
 }
 
 
-void
-CppSQLite3Statement::bind(const char* szParam, const char* szValue)
+void CppSQLite3Statement::reset()
 {
-	int nParam = bindParameterIndex(szParam);
-	bind(nParam, szValue);
+    if (mpVM)
+    {
+        int nRet = sqlite3_reset(mpVM);
+
+        if (nRet != SQLITE_OK)
+        {
+            const char* szError = sqlite3_errmsg(mpDB);
+            throw CppSQLite3Exception(nRet, (char*)szError, DONT_DELETE_MSG);
+        }
+    }
 }
 
 
-void
-CppSQLite3Statement::bind(const char* szParam, const int nValue)
+void CppSQLite3Statement::finalize()
 {
-	int nParam = bindParameterIndex(szParam);
-	bind(nParam, nValue);
+    if (mpVM)
+    {
+        int nRet = sqlite3_finalize(mpVM);
+        mpVM = 0;
+
+        if (nRet != SQLITE_OK)
+        {
+            const char* szError = sqlite3_errmsg(mpDB);
+            throw CppSQLite3Exception(nRet, (char*)szError, DONT_DELETE_MSG);
+        }
+    }
 }
 
-void
-CppSQLite3Statement::bind(const char* szParam, const double dwValue)
+
+void CppSQLite3Statement::checkDB() const
 {
-	int nParam = bindParameterIndex(szParam);
-	bind(nParam, dwValue);
+    if (mpDB == 0)
+    {
+        throw CppSQLite3Exception(CPPSQLITE_ERROR,
+                                "Database not open",
+                                DONT_DELETE_MSG);
+    }
 }
 
-void
-CppSQLite3Statement::bind(const char* szParam, const unsigned char* blobValue, int nLen)
+
+void CppSQLite3Statement::checkVM() const
 {
-	int nParam = bindParameterIndex(szParam);
-	bind(nParam, blobValue, nLen);
+    if (mpVM == 0)
+    {
+        throw CppSQLite3Exception(CPPSQLITE_ERROR,
+                                "Null Virtual Machine pointer",
+                                DONT_DELETE_MSG);
+    }
 }
 
-
-void
-CppSQLite3Statement::bindNull(const char* szParam)
-{
-	int nParam = bindParameterIndex(szParam);
-	bindNull(nParam);
-}
-
-
-void
-CppSQLite3Statement::reset()
-{
-	if (mpVM) {
-		int nRet = sqlite3_reset(mpVM);
-
-		if (nRet != SQLITE_OK) {
-			const char* szError = sqlite3_errmsg(mpDB);
-			throw CppSQLite3Exception(nRet, (char*)szError, DONT_DELETE_MSG);
-		}
-	}
-}
-
-
-void
-CppSQLite3Statement::finalize()
-{
-	if (mpVM) {
-		int nRet = sqlite3_finalize(mpVM);
-		mpVM = 0;
-
-		if (nRet != SQLITE_OK) {
-			const char* szError = sqlite3_errmsg(mpDB);
-			throw CppSQLite3Exception(nRet, (char*)szError, DONT_DELETE_MSG);
-		}
-	}
-}
-
-
-void
-CppSQLite3Statement::checkDB()
-{
-	if (mpDB == 0) {
-		throw CppSQLite3Exception(CPPSQLITE_ERROR, "Database not open", DONT_DELETE_MSG);
-	}
-}
-
-
-void
-CppSQLite3Statement::checkVM()
-{
-	if (mpVM == 0) {
-		throw CppSQLite3Exception(CPPSQLITE_ERROR, "Null Virtual Machine pointer", DONT_DELETE_MSG);
-	}
-}
 
 ////////////////////////////////////////////////////////////////////////////////
 
 CppSQLite3DB::CppSQLite3DB()
 {
-	mpDB = 0;
-	mnBusyTimeoutMs = 60000;  // 60 seconds
+    mpDB = 0;
+    mnBusyTimeoutMs = 60000; // 60 seconds
 }
+
 
 CppSQLite3DB::CppSQLite3DB(const CppSQLite3DB& db)
 {
-	mpDB = db.mpDB;
-	mnBusyTimeoutMs = 60000;  // 60 seconds
+    mpDB = db.mpDB;
+    mnBusyTimeoutMs = 60000; // 60 seconds
 }
+
 
 CppSQLite3DB::~CppSQLite3DB()
 {
-	try {
-		close();
-	} catch (...) {
-	}
+    close();
 }
 
 
-CppSQLite3DB&
-CppSQLite3DB::operator=(const CppSQLite3DB& db)
+CppSQLite3DB& CppSQLite3DB::operator=(const CppSQLite3DB& db)
 {
-	mpDB = db.mpDB;
-	mnBusyTimeoutMs = 60000;  // 60 seconds
-	return *this;
+    mpDB = db.mpDB;
+    mnBusyTimeoutMs = 60000; // 60 seconds
+    return *this;
 }
 
 
-void
-CppSQLite3DB::open(const char* szFile)
+void CppSQLite3DB::open(const char* szFile)
 {
-	int nRet = sqlite3_open(szFile, &mpDB);
+    int nRet = sqlite3_open(szFile, &mpDB);
 
-	if (nRet != SQLITE_OK) {
-		const char* szError = sqlite3_errmsg(mpDB);
-		throw CppSQLite3Exception(nRet, (char*)szError, DONT_DELETE_MSG);
-	}
+    if (nRet != SQLITE_OK)
+    {
+        const char* szError = sqlite3_errmsg(mpDB);
+        throw CppSQLite3Exception(nRet, (char*)szError, DONT_DELETE_MSG);
+    }
 
-	setBusyTimeout(mnBusyTimeoutMs);
+    setBusyTimeout(mnBusyTimeoutMs);
 }
 
 
-void
-CppSQLite3DB::close()
+void CppSQLite3DB::close()
 {
-	if (mpDB) {
-		if (sqlite3_close(mpDB) == SQLITE_OK) {
-			mpDB = 0;
-		} else {
-			throw CppSQLite3Exception(CPPSQLITE_ERROR, "Unable to close database", DONT_DELETE_MSG);
-		}
-	}
+    if (mpDB)
+    {
+        sqlite3_close(mpDB);
+        mpDB = 0;
+    }
 }
 
 
-CppSQLite3Statement
-CppSQLite3DB::compileStatement(const char* szSQL)
+CppSQLite3Statement CppSQLite3DB::compileStatement(const char* szSQL)
 {
-	checkDB();
+    checkDB();
 
-	sqlite3_stmt* pVM = compile(szSQL);
-	return CppSQLite3Statement(mpDB, pVM);
+    sqlite3_stmt* pVM = compile(szSQL);
+    return CppSQLite3Statement(mpDB, pVM);
 }
 
 
-bool
-CppSQLite3DB::tableExists(const char* szTable)
+bool CppSQLite3DB::tableExists(const char* szTable)
 {
-	char szSQL[256];
-	sprintf(szSQL, "select count(*) from sqlite_master where type='table' and name='%s'", szTable);
-	int nRet = execScalar(szSQL);
-	return (nRet > 0);
+    CppSQLite3Buffer sql;
+    sql.format( "select count(*) from sqlite_master where type='table' and name=%Q",
+                szTable );
+    int nRet = execScalar(sql);
+    return (nRet > 0);
 }
 
 
-int
-CppSQLite3DB::execDML(const char* szSQL)
+int CppSQLite3DB::execDML(const char* szSQL)
 {
-	checkDB();
+    checkDB();
 
-	char* szError = 0;
+    char* szError=0;
 
-	int nRet = sqlite3_exec(mpDB, szSQL, 0, 0, &szError);
+    int nRet = sqlite3_exec(mpDB, szSQL, 0, 0, &szError);
 
-	if (nRet == SQLITE_OK) {
-		return sqlite3_changes(mpDB);
-	} else {
-		throw CppSQLite3Exception(nRet, szError);
-	}
+    if (nRet == SQLITE_OK)
+    {
+        return sqlite3_changes(mpDB);
+    }
+    else
+    {
+        throw CppSQLite3Exception(nRet, szError);
+    }
 }
 
 
-CppSQLite3Query
-CppSQLite3DB::execQuery(const char* szSQL)
+CppSQLite3Query CppSQLite3DB::execQuery(const char* szSQL)
 {
-	checkDB();
+    checkDB();
 
-	sqlite3_stmt* pVM = compile(szSQL);
+    sqlite3_stmt* pVM = compile(szSQL);
 
-	int nRet = sqlite3_step(pVM);
+    int nRet = sqlite3_step(pVM);
 
-	if (nRet == SQLITE_DONE) {
-		// no rows
-		return CppSQLite3Query(mpDB, pVM, true /*eof*/);
-	} else if (nRet == SQLITE_ROW) {
-		// at least 1 row
-		return CppSQLite3Query(mpDB, pVM, false /*eof*/);
-	} else {
-		nRet = sqlite3_finalize(pVM);
-		const char* szError = sqlite3_errmsg(mpDB);
-		throw CppSQLite3Exception(nRet, (char*)szError, DONT_DELETE_MSG);
-	}
+    if (nRet == SQLITE_DONE)
+    {
+        // no rows
+        return CppSQLite3Query(mpDB, pVM, true/*eof*/);
+    }
+    else if (nRet == SQLITE_ROW)
+    {
+        // at least 1 row
+        return CppSQLite3Query(mpDB, pVM, false/*eof*/);
+    }
+    else
+    {
+        nRet = sqlite3_finalize(pVM);
+        const char* szError= sqlite3_errmsg(mpDB);
+        throw CppSQLite3Exception(nRet, (char*)szError, DONT_DELETE_MSG);
+    }
 }
 
 
-int
-CppSQLite3DB::execScalar(const char* szSQL, int nNullValue /*=0*/)
+int CppSQLite3DB::execScalar(const char* szSQL)
 {
-	CppSQLite3Query q = execQuery(szSQL);
+    CppSQLite3Query q = execQuery(szSQL);
 
-	if (q.eof() || q.numFields() < 1) {
-		throw CppSQLite3Exception(CPPSQLITE_ERROR, "Invalid scalar query", DONT_DELETE_MSG);
-	}
+    if (q.eof() || q.numFields() < 1)
+    {
+        throw CppSQLite3Exception(CPPSQLITE_ERROR,
+                                "Invalid scalar query",
+                                DONT_DELETE_MSG);
+    }
 
-	return q.getIntField(0, nNullValue);
+    return atoi(q.fieldValue(0));
 }
 
 
-CppSQLite3Table
-CppSQLite3DB::getTable(const char* szSQL)
+CppSQLite3Table CppSQLite3DB::getTable(const char* szSQL)
 {
-	checkDB();
+    checkDB();
 
-	char* szError = 0;
-	char** paszResults = 0;
-	int nRet;
-	int nRows(0);
-	int nCols(0);
+    char* szError=0;
+    char** paszResults=0;
+    int nRet;
+    int nRows(0);
+    int nCols(0);
 
-	nRet = sqlite3_get_table(mpDB, szSQL, &paszResults, &nRows, &nCols, &szError);
+    nRet = sqlite3_get_table(mpDB, szSQL, &paszResults, &nRows, &nCols, &szError);
 
-	if (nRet == SQLITE_OK) {
-		return CppSQLite3Table(paszResults, nRows, nCols);
-	} else {
-		throw CppSQLite3Exception(nRet, szError);
-	}
+    if (nRet == SQLITE_OK)
+    {
+        return CppSQLite3Table(paszResults, nRows, nCols);
+    }
+    else
+    {
+        throw CppSQLite3Exception(nRet, szError);
+    }
 }
 
 
-sqlite_int64
-CppSQLite3DB::lastRowId()
+sqlite_int64 CppSQLite3DB::lastRowId() const
 {
-	return sqlite3_last_insert_rowid(mpDB);
+    return sqlite3_last_insert_rowid(mpDB);
 }
 
 
-void
-CppSQLite3DB::setBusyTimeout(int nMillisecs)
+void CppSQLite3DB::setBusyTimeout(int nMillisecs)
 {
-	mnBusyTimeoutMs = nMillisecs;
-	sqlite3_busy_timeout(mpDB, mnBusyTimeoutMs);
+    mnBusyTimeoutMs = nMillisecs;
+    sqlite3_busy_timeout(mpDB, mnBusyTimeoutMs);
 }
 
 
-void
-CppSQLite3DB::checkDB()
+void CppSQLite3DB::checkDB() const
 {
-	if (!mpDB) {
-		throw CppSQLite3Exception(CPPSQLITE_ERROR, "Database not open", DONT_DELETE_MSG);
-	}
+    if (!mpDB)
+    {
+        throw CppSQLite3Exception(CPPSQLITE_ERROR,
+                                "Database not open",
+                                DONT_DELETE_MSG);
+    }
 }
 
 
-sqlite3_stmt*
-CppSQLite3DB::compile(const char* szSQL)
+sqlite3_stmt* CppSQLite3DB::compile(const char* szSQL)
 {
-	checkDB();
+    checkDB();
 
-	const char* szTail = 0;
-	sqlite3_stmt* pVM;
+    char* szError=0;
+    const char* szTail=0;
+    sqlite3_stmt* pVM;
 
-	int nRet = sqlite3_prepare_v2(mpDB, szSQL, -1, &pVM, &szTail);
+    int nRet = sqlite3_prepare(mpDB, szSQL, -1, &pVM, &szTail);
 
-	if (nRet != SQLITE_OK) {
-		const char* szError = sqlite3_errmsg(mpDB);
-		throw CppSQLite3Exception(nRet, (char*)szError, DONT_DELETE_MSG);
-	}
+    if (nRet != SQLITE_OK)
+    {
+        throw CppSQLite3Exception(nRet, szError);
+    }
 
-	return pVM;
+    return pVM;
 }
 
-bool
-CppSQLite3DB::IsAutoCommitOn()
-{
-	checkDB();
-	return sqlite3_get_autocommit(mpDB) ? true : false;
-}
 
 ////////////////////////////////////////////////////////////////////////////////
 // SQLite encode.c reproduced here, containing implementation notes and source
@@ -1421,52 +1552,46 @@ CppSQLite3DB::IsAutoCommitOn()
 ** The return value is the number of characters in the encoded
 ** string, excluding the "\000" terminator.
 */
-int
-sqlite3_encode_binary(const unsigned char* in, int n, unsigned char* out)
-{
-	int i, j, e, m;
-	int cnt[256];
-	if (n <= 0) {
-		out[0] = 'x';
-		out[1] = 0;
-		return 1;
-	}
-	memset(cnt, 0, sizeof(cnt));
-	for (i = n - 1; i >= 0; i--) {
-		cnt[in[i]]++;
-	}
-	m = n;
-	for (i = 1; i < 256; i++) {
-		int sum;
-		if (i == '\'')
-			continue;
-		sum = cnt[i] + cnt[(i + 1) & 0xff] + cnt[(i + '\'') & 0xff];
-		if (sum < m) {
-			m = sum;
-			e = i;
-			if (m == 0)
-				break;
-		}
-	}
-	out[0] = e;
-	j = 1;
-	for (i = 0; i < n; i++) {
-		int c = (in[i] - e) & 0xff;
-		if (c == 0) {
-			out[j++] = 1;
-			out[j++] = 1;
-		} else if (c == 1) {
-			out[j++] = 1;
-			out[j++] = 2;
-		} else if (c == '\'') {
-			out[j++] = 1;
-			out[j++] = 3;
-		} else {
-			out[j++] = c;
-		}
-	}
-	out[j] = 0;
-	return j;
+int sqlite3_encode_binary(const unsigned char *in, int n, unsigned char *out){
+  int i, j, e, m;
+  int cnt[256];
+  if( n<=0 ){
+    out[0] = 'x';
+    out[1] = 0;
+    return 1;
+  }
+  memset(cnt, 0, sizeof(cnt));
+  for(i=n-1; i>=0; i--){ cnt[in[i]]++; }
+  m = n;
+  for(i=1; i<256; i++){
+    int sum;
+    if( i=='\'' ) continue;
+    sum = cnt[i] + cnt[(i+1)&0xff] + cnt[(i+'\'')&0xff];
+    if( sum<m ){
+      m = sum;
+      e = i;
+      if( m==0 ) break;
+    }
+  }
+  out[0] = e;
+  j = 1;
+  for(i=0; i<n; i++){
+    int c = (in[i] - e)&0xff;
+    if( c==0 ){
+      out[j++] = 1;
+      out[j++] = 1;
+    }else if( c==1 ){
+      out[j++] = 1;
+      out[j++] = 2;
+    }else if( c=='\'' ){
+      out[j++] = 1;
+      out[j++] = 3;
+    }else{
+      out[j++] = c;
+    }
+  }
+  out[j] = 0;
+  return j;
 }
 
 /*
@@ -1479,26 +1604,24 @@ sqlite3_encode_binary(const unsigned char* in, int n, unsigned char* out)
 ** The "in" and "out" parameters may point to the same buffer in order
 ** to decode a string in place.
 */
-int
-sqlite3_decode_binary(const unsigned char* in, unsigned char* out)
-{
-	int i, c, e;
-	e = *(in++);
-	i = 0;
-	while ((c = *(in++)) != 0) {
-		if (c == 1) {
-			c = *(in++);
-			if (c == 1) {
-				c = 0;
-			} else if (c == 2) {
-				c = 1;
-			} else if (c == 3) {
-				c = '\'';
-			} else {
-				return -1;
-			}
-		}
-		out[i++] = (c + e) & 0xff;
-	}
-	return i;
+int sqlite3_decode_binary(const unsigned char *in, unsigned char *out){
+  int i, c, e;
+  e = *(in++);
+  i = 0;
+  while( (c = *(in++))!=0 ){
+    if( c==1 ){
+      c = *(in++);
+      if( c==1 ){
+        c = 0;
+      }else if( c==2 ){
+        c = 1;
+      }else if( c==3 ){
+        c = '\'';
+      }else{
+        return -1;
+      }
+    }
+    out[i++] = (c + e)&0xff;
+  }
+  return i;
 }

--- a/src/CppSQLite3.h
+++ b/src/CppSQLite3.h
@@ -1,339 +1,303 @@
-/*
- * CppSQLite
- * Developed by Rob Groves <rob.groves@btinternet.com>
- * Maintained by NeoSmart Technologies <http://neosmart.net/>
- * See LICENSE file for copyright and license info
-*/
+////////////////////////////////////////////////////////////////////////////////
+// CppSQLite3 - A C++ wrapper around the SQLite3 embedded database library.
+//
+// Copyright (c) 2004..2007 Rob Groves. All Rights Reserved. rob.groves@btinternet.com
+//
+// Permission to use, copy, modify, and distribute this software and its
+// documentation for any purpose, without fee, and without a written
+// agreement, is hereby granted, provided that the above copyright notice,
+// this paragraph and the following two paragraphs appear in all copies,
+// modifications, and distributions.
+//
+// IN NO EVENT SHALL THE AUTHOR BE LIABLE TO ANY PARTY FOR DIRECT,
+// INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST
+// PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+// EVEN IF THE AUTHOR HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// THE AUTHOR SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+// PARTICULAR PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF
+// ANY, PROVIDED HEREUNDER IS PROVIDED "AS IS". THE AUTHOR HAS NO OBLIGATION
+// TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+//
+// V3.0		03/08/2004	-Initial Version for sqlite3
+//
+// V3.1		16/09/2004	-Implemented getXXXXField using sqlite3 functions
+//						-Added CppSQLiteDB3::tableExists()
+//
+// V3.2		01/07/2005	-Fixed execScalar to handle a NULL result
+//			12/07/2007	-Added CppSQLiteDB::IsAutoCommitOn()
+//						-Added int64 functions to CppSQLite3Query
+//						-Added Name based parameter binding to CppSQLite3Statement.
+////////////////////////////////////////////////////////////////////////////////
+#ifndef _CppSQLite3_H_
+#define _CppSQLite3_H_
 
-#ifndef CppSQLite3_H
-#define CppSQLite3_H
-
-#include <sqlite3.h>
 #include <cstdio>
 #include <cstring>
-#include <exception>
+#include "sqlite3.h"
 
 #define CPPSQLITE_ERROR 1000
 
-namespace detail
-{
-    /**
-     * RAII class for managing memory allocated by sqlite
-    */
-    class SQLite3Memory
-    {
-    public:
-
-        // Default constructor
-        SQLite3Memory();
-        // Constructor that allocates memory of a given size
-        SQLite3Memory(int nBufferLen);
-        // Constructor that formats a string with sqlite memory allocation
-        SQLite3Memory(const char* szFormat, va_list list);
-        // Destructor
-        ~SQLite3Memory();
-
-        // Copy constructor
-        SQLite3Memory(SQLite3Memory const& other);
-        // Copy assignment
-        SQLite3Memory& operator=(SQLite3Memory const& lhs);
-
-        // Move constructor
-        SQLite3Memory(SQLite3Memory&& other);
-        // Move assignment
-        SQLite3Memory& operator=(SQLite3Memory&& lhs);
-
-        // Swap operation
-        void swap(SQLite3Memory& other);
-
-        int getLength() const { return mnBufferLen; }
-
-        void* getBuffer() const { return mpBuf; }
-
-        void clear();
-
-    private:
-
-        int mnBufferLen;
-        void* mpBuf;
-    };
-}
-
-
-class CppSQLite3Exception : public std::exception
-{
+class CppSQLite3Exception {
 public:
+	CppSQLite3Exception(const int nErrCode, char* szErrMess, bool bDeleteMsg = true);
 
-    CppSQLite3Exception(const int nErrCode,
-                    const char* szErrMess,
-                    bool bDeleteMsg=true);
+	CppSQLite3Exception(const CppSQLite3Exception& e);
 
-    CppSQLite3Exception(const CppSQLite3Exception&  e);
+	virtual ~CppSQLite3Exception();
 
-    virtual ~CppSQLite3Exception();
+	const int errorCode() { return mnErrCode; }
 
-    const int errorCode() const { return mnErrCode; }
+	const char* errorMessage() { return mpszErrMess; }
 
-    const char* errorMessage() const { return mpszErrMess; }
-
-    const char* what() const noexcept override { return mpszErrMess; }
-
-    static const char* errorCodeAsString(int nErrCode);
+	static const char* errorCodeAsString(int nErrCode);
 
 private:
-
-    int mnErrCode;
-    char* mpszErrMess;
+	int mnErrCode;
+	char* mpszErrMess;
 };
 
 
-class CppSQLite3Buffer
-{
+class CppSQLite3Buffer {
 public:
-    const char* format(const char* szFormat, ...);
+	CppSQLite3Buffer();
 
-    operator const char*() { return static_cast<char const*>(mBuf.getBuffer()); }
+	~CppSQLite3Buffer();
 
-    void clear();
+	const char* format(const char* szFormat, ...);
+
+	operator const char*() { return mpBuf; }
+
+	void clear();
 
 private:
-
-    detail::SQLite3Memory mBuf;
+	char* mpBuf;
 };
 
 
-class CppSQLite3Binary
-{
+class CppSQLite3Binary {
 public:
+	CppSQLite3Binary();
 
-    CppSQLite3Binary();
+	~CppSQLite3Binary();
 
-    ~CppSQLite3Binary();
+	void setBinary(const unsigned char* pBuf, int nLen);
+	void setEncoded(const unsigned char* pBuf);
 
-    void setBinary(const unsigned char* pBuf, int nLen);
-    void setEncoded(const unsigned char* pBuf);
+	const unsigned char* getEncoded();
+	const unsigned char* getBinary();
 
-    const unsigned char* getEncoded();
-    const unsigned char* getBinary();
+	int getBinaryLength();
 
-    int getBinaryLength();
+	unsigned char* allocBuffer(int nLen);
 
-    unsigned char* allocBuffer(int nLen);
-
-    void clear();
+	void clear();
 
 private:
-
-    unsigned char* mpBuf;
-    int mnBinaryLen;
-    int mnBufferLen;
-    int mnEncodedLen;
-    bool mbEncoded;
+	unsigned char* mpBuf;
+	int mnBinaryLen;
+	int mnBufferLen;
+	int mnEncodedLen;
+	bool mbEncoded;
 };
 
 
-class CppSQLite3Query
-{
+class CppSQLite3Query {
 public:
+	CppSQLite3Query();
 
-    CppSQLite3Query();
+	CppSQLite3Query(const CppSQLite3Query& rQuery);
 
-    CppSQLite3Query(const CppSQLite3Query& rQuery);
+	CppSQLite3Query(sqlite3* pDB, sqlite3_stmt* pVM, bool bEof, bool bOwnVM = true);
 
-    CppSQLite3Query(sqlite3* pDB,
-                sqlite3_stmt* pVM,
-                bool bEof,
-                bool bOwnVM=true);
+	CppSQLite3Query& operator=(const CppSQLite3Query& rQuery);
 
-    CppSQLite3Query& operator=(const CppSQLite3Query& rQuery);
+	virtual ~CppSQLite3Query();
 
-    virtual ~CppSQLite3Query();
+	int numFields();
 
-    int numFields() const;
+	int fieldIndex(const char* szField);
+	const char* fieldName(int nCol);
 
-    int fieldIndex(const char* szField) const;
-    const char* fieldName(int nCol) const;
+	const char* fieldDeclType(int nCol);
+	int fieldDataType(int nCol);
 
-    const char* fieldDeclType(int nCol) const;
-    int fieldDataType(int nCol) const;
+	const char* fieldValue(int nField);
+	const char* fieldValue(const char* szField);
 
-    const char* fieldValue(int nField) const;
-    const char* fieldValue(const char* szField) const;
+	int getIntField(int nField, int nNullValue = 0);
+	int getIntField(const char* szField, int nNullValue = 0);
 
-    int getIntField(int nField, int nNullValue=0) const;
-    int getIntField(const char* szField, int nNullValue=0) const;
+	sqlite_int64 getInt64Field(int nField, sqlite_int64 nNullValue = 0);
+	sqlite_int64 getInt64Field(const char* szField, sqlite_int64 nNullValue = 0);
 
-    long long getInt64Field(int nField, long long nNullValue=0) const;
-    long long getInt64Field(const char* szField, long long nNullValue=0) const;
+	double getFloatField(int nField, double fNullValue = 0.0);
+	double getFloatField(const char* szField, double fNullValue = 0.0);
 
-    float getFloatField(int nField, float fNullValue=0.0f) const;
-    float getFloatField(const char* szField, float fNullValue=0.0f) const;
+	const char* getStringField(int nField, const char* szNullValue = "");
+	const char* getStringField(const char* szField, const char* szNullValue = "");
 
-    double getDoubleField(int nField, double dNullValue=0.0) const;
-    double getDoubleField(const char* szField, double dNullValue=0.0) const;
+	const unsigned char* getBlobField(int nField, int& nLen);
+	const unsigned char* getBlobField(const char* szField, int& nLen);
 
-    const char* getStringField(int nField, const char* szNullValue="") const;
-    const char* getStringField(const char* szField, const char* szNullValue="") const;
+	bool fieldIsNull(int nField);
+	bool fieldIsNull(const char* szField);
 
-    const unsigned char* getBlobField(int nField, int& nLen) const;
-    const unsigned char* getBlobField(const char* szField, int& nLen) const;
+	bool eof();
 
-    bool fieldIsNull(int nField) const;
-    bool fieldIsNull(const char* szField) const;
+	void nextRow();
 
-    bool eof() const;
-
-    void nextRow();
-
-    void finalize();
+	void finalize();
 
 private:
+	void checkVM();
 
-    void checkVM() const;
-
-    sqlite3* mpDB;
-    sqlite3_stmt* mpVM;
-    bool mbEof;
-    int mnCols;
-    bool mbOwnVM;
+	sqlite3* mpDB;
+	sqlite3_stmt* mpVM;
+	bool mbEof;
+	int mnCols;
+	bool mbOwnVM;
 };
 
 
-class CppSQLite3Table
-{
+class CppSQLite3Table {
 public:
+	CppSQLite3Table();
 
-    CppSQLite3Table();
+	CppSQLite3Table(const CppSQLite3Table& rTable);
 
-    CppSQLite3Table(const CppSQLite3Table& rTable);
+	CppSQLite3Table(char** paszResults, int nRows, int nCols);
 
-    CppSQLite3Table(char** paszResults, int nRows, int nCols);
+	virtual ~CppSQLite3Table();
 
-    virtual ~CppSQLite3Table();
+	CppSQLite3Table& operator=(const CppSQLite3Table& rTable);
 
-    CppSQLite3Table& operator=(const CppSQLite3Table& rTable);
+	int numFields();
 
-    int numFields() const;
+	int numRows();
 
-    int numRows() const;
+	const char* fieldName(int nCol);
 
-    const char* fieldName(int nCol) const;
+	const char* fieldValue(int nField);
+	const char* fieldValue(const char* szField);
 
-    const char* fieldValue(int nField) const;
-    const char* fieldValue(const char* szField) const;
+	int getIntField(int nField, int nNullValue = 0);
+	int getIntField(const char* szField, int nNullValue = 0);
 
-    int getIntField(int nField, int nNullValue=0) const;
-    int getIntField(const char* szField, int nNullValue=0) const;
+	double getFloatField(int nField, double fNullValue = 0.0);
+	double getFloatField(const char* szField, double fNullValue = 0.0);
 
-    float getFloatField(int nField, float fNullValue=0.0f) const;
-    float getFloatField(const char* szField, float fNullValue=0.0f) const;
+	const char* getStringField(int nField, const char* szNullValue = "");
+	const char* getStringField(const char* szField, const char* szNullValue = "");
 
-    double getDoubleField(int nField, double dNullValue=0.0) const;
-    double getDoubleField(const char* szField, double dNullValue=0.0) const;
+	bool fieldIsNull(int nField);
+	bool fieldIsNull(const char* szField);
 
-    const char* getStringField(int nField, const char* szNullValue="") const;
-    const char* getStringField(const char* szField, const char* szNullValue="") const;
+	void setRow(int nRow);
 
-    bool fieldIsNull(int nField) const;
-    bool fieldIsNull(const char* szField) const;
-
-    void setRow(int nRow);
-
-    void finalize();
+	void finalize();
 
 private:
+	void checkResults();
 
-    void checkResults() const;
-
-    int mnCols;
-    int mnRows;
-    int mnCurrentRow;
-    char** mpaszResults;
+	int mnCols;
+	int mnRows;
+	int mnCurrentRow;
+	char** mpaszResults;
 };
 
 
-class CppSQLite3Statement
-{
+class CppSQLite3Statement {
 public:
+	CppSQLite3Statement();
 
-    CppSQLite3Statement();
+	CppSQLite3Statement(const CppSQLite3Statement& rStatement);
 
-    CppSQLite3Statement(const CppSQLite3Statement& rStatement);
+	CppSQLite3Statement(sqlite3* pDB, sqlite3_stmt* pVM);
 
-    CppSQLite3Statement(sqlite3* pDB, sqlite3_stmt* pVM);
+	virtual ~CppSQLite3Statement();
 
-    virtual ~CppSQLite3Statement();
+	CppSQLite3Statement& operator=(const CppSQLite3Statement& rStatement);
 
-    CppSQLite3Statement& operator=(const CppSQLite3Statement& rStatement);
+	int execDML();
 
-    int execDML();
+	CppSQLite3Query execQuery();
 
-    CppSQLite3Query execQuery();
+	void bind(int nParam, const char* szValue);
+	void bind(int nParam, const int nValue);
+	void bind(int nParam, const double dwValue);
+	void bind(int nParam, const unsigned char* blobValue, int nLen);
+	void bindNull(int nParam);
 
-    void bind(int nParam, const char* szValue);
-    void bind(int nParam, const int nValue);
-    void bind(int nParam, const long long nValue);
-    void bind(int nParam, const double dwValue);
-    void bind(int nParam, const unsigned char* blobValue, int nLen);
-    void bindNull(int nParam);
+	int bindParameterIndex(const char* szParam);
+	void bind(const char* szParam, const char* szValue);
+	void bind(const char* szParam, const int nValue);
+	void bind(const char* szParam, const double dwValue);
+	void bind(const char* szParam, const unsigned char* blobValue, int nLen);
+	void bindNull(const char* szParam);
 
-    void reset();
+	void reset();
 
-    void finalize();
+	void finalize();
 
 private:
+	void checkDB();
+	void checkVM();
 
-    void checkDB() const;
-    void checkVM() const;
-
-    sqlite3* mpDB;
-    sqlite3_stmt* mpVM;
+	sqlite3* mpDB;
+	sqlite3_stmt* mpVM;
 };
 
 
-class CppSQLite3DB
-{
+class CppSQLite3DB {
 public:
+	CppSQLite3DB();
 
-    CppSQLite3DB();
+	virtual ~CppSQLite3DB();
 
-    virtual ~CppSQLite3DB();
+	void open(const char* szFile);
 
-    void open(const char* szFile);
+	void close();
 
-    void close();
+	bool tableExists(const char* szTable);
 
-    bool tableExists(const char* szTable);
+	int execDML(const char* szSQL);
 
-    int execDML(const char* szSQL);
+	CppSQLite3Query execQuery(const char* szSQL);
 
-    CppSQLite3Query execQuery(const char* szSQL);
+	int execScalar(const char* szSQL, int nNullValue = 0);
 
-    int execScalar(const char* szSQL);
+	CppSQLite3Table getTable(const char* szSQL);
 
-    CppSQLite3Table getTable(const char* szSQL);
+	CppSQLite3Statement compileStatement(const char* szSQL);
 
-    CppSQLite3Statement compileStatement(const char* szSQL);
+	sqlite_int64 lastRowId();
 
-    sqlite_int64 lastRowId() const;
+	void interrupt() { sqlite3_interrupt(mpDB); }
 
-    void interrupt() { sqlite3_interrupt(mpDB); }
+	void setBusyTimeout(int nMillisecs);
 
-    void setBusyTimeout(int nMillisecs);
+	static const char* SQLiteVersion() { return SQLITE_VERSION; }
 
-    static const char* SQLiteVersion() { return SQLITE_VERSION; }
+	static const char* SQLiteHeaderVersion() { return SQLITE_VERSION; }
+
+	static const char* SQLiteLibraryVersion() { return sqlite3_libversion(); }
+
+	static int SQLiteLibraryVersionNumber() { return sqlite3_libversion_number(); }
+
+	bool IsAutoCommitOn();
 
 private:
+	CppSQLite3DB(const CppSQLite3DB& db);
+	CppSQLite3DB& operator=(const CppSQLite3DB& db);
 
-    CppSQLite3DB(const CppSQLite3DB& db);
-    CppSQLite3DB& operator=(const CppSQLite3DB& db);
+	sqlite3_stmt* compile(const char* szSQL);
 
-    sqlite3_stmt* compile(const char* szSQL);
+	void checkDB();
 
-    void checkDB() const;
-
-    sqlite3* mpDB;
-    int mnBusyTimeoutMs;
+	sqlite3* mpDB;
+	int mnBusyTimeoutMs;
 };
 
 #endif

--- a/src/CppSQLite3.h
+++ b/src/CppSQLite3.h
@@ -1,303 +1,339 @@
-////////////////////////////////////////////////////////////////////////////////
-// CppSQLite3 - A C++ wrapper around the SQLite3 embedded database library.
-//
-// Copyright (c) 2004..2007 Rob Groves. All Rights Reserved. rob.groves@btinternet.com
-//
-// Permission to use, copy, modify, and distribute this software and its
-// documentation for any purpose, without fee, and without a written
-// agreement, is hereby granted, provided that the above copyright notice,
-// this paragraph and the following two paragraphs appear in all copies,
-// modifications, and distributions.
-//
-// IN NO EVENT SHALL THE AUTHOR BE LIABLE TO ANY PARTY FOR DIRECT,
-// INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST
-// PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
-// EVEN IF THE AUTHOR HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
-// THE AUTHOR SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-// PARTICULAR PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF
-// ANY, PROVIDED HEREUNDER IS PROVIDED "AS IS". THE AUTHOR HAS NO OBLIGATION
-// TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
-//
-// V3.0		03/08/2004	-Initial Version for sqlite3
-//
-// V3.1		16/09/2004	-Implemented getXXXXField using sqlite3 functions
-//						-Added CppSQLiteDB3::tableExists()
-//
-// V3.2		01/07/2005	-Fixed execScalar to handle a NULL result
-//			12/07/2007	-Added CppSQLiteDB::IsAutoCommitOn()
-//						-Added int64 functions to CppSQLite3Query
-//						-Added Name based parameter binding to CppSQLite3Statement.
-////////////////////////////////////////////////////////////////////////////////
-#ifndef _CppSQLite3_H_
-#define _CppSQLite3_H_
+/*
+ * CppSQLite
+ * Developed by Rob Groves <rob.groves@btinternet.com>
+ * Maintained by NeoSmart Technologies <http://neosmart.net/>
+ * See LICENSE file for copyright and license info
+*/
 
+#ifndef CppSQLite3_H
+#define CppSQLite3_H
+
+#include <sqlite3.h>
 #include <cstdio>
 #include <cstring>
-#include "sqlite3.h"
+#include <exception>
 
 #define CPPSQLITE_ERROR 1000
 
-class CppSQLite3Exception {
+namespace detail
+{
+    /**
+     * RAII class for managing memory allocated by sqlite
+    */
+    class SQLite3Memory
+    {
+    public:
+
+        // Default constructor
+        SQLite3Memory();
+        // Constructor that allocates memory of a given size
+        SQLite3Memory(int nBufferLen);
+        // Constructor that formats a string with sqlite memory allocation
+        SQLite3Memory(const char* szFormat, va_list list);
+        // Destructor
+        ~SQLite3Memory();
+
+        // Copy constructor
+        SQLite3Memory(SQLite3Memory const& other);
+        // Copy assignment
+        SQLite3Memory& operator=(SQLite3Memory const& lhs);
+
+        // Move constructor
+        SQLite3Memory(SQLite3Memory&& other);
+        // Move assignment
+        SQLite3Memory& operator=(SQLite3Memory&& lhs);
+
+        // Swap operation
+        void swap(SQLite3Memory& other);
+
+        int getLength() const { return mnBufferLen; }
+
+        void* getBuffer() const { return mpBuf; }
+
+        void clear();
+
+    private:
+
+        int mnBufferLen;
+        void* mpBuf;
+    };
+}
+
+
+class CppSQLite3Exception : public std::exception
+{
 public:
-	CppSQLite3Exception(const int nErrCode, char* szErrMess, bool bDeleteMsg = true);
 
-	CppSQLite3Exception(const CppSQLite3Exception& e);
+    CppSQLite3Exception(const int nErrCode,
+                    const char* szErrMess,
+                    bool bDeleteMsg=true);
 
-	virtual ~CppSQLite3Exception();
+    CppSQLite3Exception(const CppSQLite3Exception&  e);
 
-	const int errorCode() { return mnErrCode; }
+    virtual ~CppSQLite3Exception();
 
-	const char* errorMessage() { return mpszErrMess; }
+    const int errorCode() const { return mnErrCode; }
 
-	static const char* errorCodeAsString(int nErrCode);
+    const char* errorMessage() const { return mpszErrMess; }
+
+    const char* what() const noexcept override { return mpszErrMess; }
+
+    static const char* errorCodeAsString(int nErrCode);
 
 private:
-	int mnErrCode;
-	char* mpszErrMess;
+
+    int mnErrCode;
+    char* mpszErrMess;
 };
 
 
-class CppSQLite3Buffer {
+class CppSQLite3Buffer
+{
 public:
-	CppSQLite3Buffer();
+    const char* format(const char* szFormat, ...);
 
-	~CppSQLite3Buffer();
+    operator const char*() { return static_cast<char const*>(mBuf.getBuffer()); }
 
-	const char* format(const char* szFormat, ...);
-
-	operator const char*() { return mpBuf; }
-
-	void clear();
+    void clear();
 
 private:
-	char* mpBuf;
+
+    detail::SQLite3Memory mBuf;
 };
 
 
-class CppSQLite3Binary {
+class CppSQLite3Binary
+{
 public:
-	CppSQLite3Binary();
 
-	~CppSQLite3Binary();
+    CppSQLite3Binary();
 
-	void setBinary(const unsigned char* pBuf, int nLen);
-	void setEncoded(const unsigned char* pBuf);
+    ~CppSQLite3Binary();
 
-	const unsigned char* getEncoded();
-	const unsigned char* getBinary();
+    void setBinary(const unsigned char* pBuf, int nLen);
+    void setEncoded(const unsigned char* pBuf);
 
-	int getBinaryLength();
+    const unsigned char* getEncoded();
+    const unsigned char* getBinary();
 
-	unsigned char* allocBuffer(int nLen);
+    int getBinaryLength();
 
-	void clear();
+    unsigned char* allocBuffer(int nLen);
+
+    void clear();
 
 private:
-	unsigned char* mpBuf;
-	int mnBinaryLen;
-	int mnBufferLen;
-	int mnEncodedLen;
-	bool mbEncoded;
+
+    unsigned char* mpBuf;
+    int mnBinaryLen;
+    int mnBufferLen;
+    int mnEncodedLen;
+    bool mbEncoded;
 };
 
 
-class CppSQLite3Query {
+class CppSQLite3Query
+{
 public:
-	CppSQLite3Query();
 
-	CppSQLite3Query(const CppSQLite3Query& rQuery);
+    CppSQLite3Query();
 
-	CppSQLite3Query(sqlite3* pDB, sqlite3_stmt* pVM, bool bEof, bool bOwnVM = true);
+    CppSQLite3Query(const CppSQLite3Query& rQuery);
 
-	CppSQLite3Query& operator=(const CppSQLite3Query& rQuery);
+    CppSQLite3Query(sqlite3* pDB,
+                sqlite3_stmt* pVM,
+                bool bEof,
+                bool bOwnVM=true);
 
-	virtual ~CppSQLite3Query();
+    CppSQLite3Query& operator=(const CppSQLite3Query& rQuery);
 
-	int numFields();
+    virtual ~CppSQLite3Query();
 
-	int fieldIndex(const char* szField);
-	const char* fieldName(int nCol);
+    int numFields() const;
 
-	const char* fieldDeclType(int nCol);
-	int fieldDataType(int nCol);
+    int fieldIndex(const char* szField) const;
+    const char* fieldName(int nCol) const;
 
-	const char* fieldValue(int nField);
-	const char* fieldValue(const char* szField);
+    const char* fieldDeclType(int nCol) const;
+    int fieldDataType(int nCol) const;
 
-	int getIntField(int nField, int nNullValue = 0);
-	int getIntField(const char* szField, int nNullValue = 0);
+    const char* fieldValue(int nField) const;
+    const char* fieldValue(const char* szField) const;
 
-	sqlite_int64 getInt64Field(int nField, sqlite_int64 nNullValue = 0);
-	sqlite_int64 getInt64Field(const char* szField, sqlite_int64 nNullValue = 0);
+    int getIntField(int nField, int nNullValue=0) const;
+    int getIntField(const char* szField, int nNullValue=0) const;
 
-	double getFloatField(int nField, double fNullValue = 0.0);
-	double getFloatField(const char* szField, double fNullValue = 0.0);
+    long long getInt64Field(int nField, long long nNullValue=0) const;
+    long long getInt64Field(const char* szField, long long nNullValue=0) const;
 
-	const char* getStringField(int nField, const char* szNullValue = "");
-	const char* getStringField(const char* szField, const char* szNullValue = "");
+    float getFloatField(int nField, float fNullValue=0.0f) const;
+    float getFloatField(const char* szField, float fNullValue=0.0f) const;
 
-	const unsigned char* getBlobField(int nField, int& nLen);
-	const unsigned char* getBlobField(const char* szField, int& nLen);
+    double getDoubleField(int nField, double dNullValue=0.0) const;
+    double getDoubleField(const char* szField, double dNullValue=0.0) const;
 
-	bool fieldIsNull(int nField);
-	bool fieldIsNull(const char* szField);
+    const char* getStringField(int nField, const char* szNullValue="") const;
+    const char* getStringField(const char* szField, const char* szNullValue="") const;
 
-	bool eof();
+    const unsigned char* getBlobField(int nField, int& nLen) const;
+    const unsigned char* getBlobField(const char* szField, int& nLen) const;
 
-	void nextRow();
+    bool fieldIsNull(int nField) const;
+    bool fieldIsNull(const char* szField) const;
 
-	void finalize();
+    bool eof() const;
+
+    void nextRow();
+
+    void finalize();
 
 private:
-	void checkVM();
 
-	sqlite3* mpDB;
-	sqlite3_stmt* mpVM;
-	bool mbEof;
-	int mnCols;
-	bool mbOwnVM;
+    void checkVM() const;
+
+    sqlite3* mpDB;
+    sqlite3_stmt* mpVM;
+    bool mbEof;
+    int mnCols;
+    bool mbOwnVM;
 };
 
 
-class CppSQLite3Table {
+class CppSQLite3Table
+{
 public:
-	CppSQLite3Table();
 
-	CppSQLite3Table(const CppSQLite3Table& rTable);
+    CppSQLite3Table();
 
-	CppSQLite3Table(char** paszResults, int nRows, int nCols);
+    CppSQLite3Table(const CppSQLite3Table& rTable);
 
-	virtual ~CppSQLite3Table();
+    CppSQLite3Table(char** paszResults, int nRows, int nCols);
 
-	CppSQLite3Table& operator=(const CppSQLite3Table& rTable);
+    virtual ~CppSQLite3Table();
 
-	int numFields();
+    CppSQLite3Table& operator=(const CppSQLite3Table& rTable);
 
-	int numRows();
+    int numFields() const;
 
-	const char* fieldName(int nCol);
+    int numRows() const;
 
-	const char* fieldValue(int nField);
-	const char* fieldValue(const char* szField);
+    const char* fieldName(int nCol) const;
 
-	int getIntField(int nField, int nNullValue = 0);
-	int getIntField(const char* szField, int nNullValue = 0);
+    const char* fieldValue(int nField) const;
+    const char* fieldValue(const char* szField) const;
 
-	double getFloatField(int nField, double fNullValue = 0.0);
-	double getFloatField(const char* szField, double fNullValue = 0.0);
+    int getIntField(int nField, int nNullValue=0) const;
+    int getIntField(const char* szField, int nNullValue=0) const;
 
-	const char* getStringField(int nField, const char* szNullValue = "");
-	const char* getStringField(const char* szField, const char* szNullValue = "");
+    float getFloatField(int nField, float fNullValue=0.0f) const;
+    float getFloatField(const char* szField, float fNullValue=0.0f) const;
 
-	bool fieldIsNull(int nField);
-	bool fieldIsNull(const char* szField);
+    double getDoubleField(int nField, double dNullValue=0.0) const;
+    double getDoubleField(const char* szField, double dNullValue=0.0) const;
 
-	void setRow(int nRow);
+    const char* getStringField(int nField, const char* szNullValue="") const;
+    const char* getStringField(const char* szField, const char* szNullValue="") const;
 
-	void finalize();
+    bool fieldIsNull(int nField) const;
+    bool fieldIsNull(const char* szField) const;
+
+    void setRow(int nRow);
+
+    void finalize();
 
 private:
-	void checkResults();
 
-	int mnCols;
-	int mnRows;
-	int mnCurrentRow;
-	char** mpaszResults;
+    void checkResults() const;
+
+    int mnCols;
+    int mnRows;
+    int mnCurrentRow;
+    char** mpaszResults;
 };
 
 
-class CppSQLite3Statement {
+class CppSQLite3Statement
+{
 public:
-	CppSQLite3Statement();
 
-	CppSQLite3Statement(const CppSQLite3Statement& rStatement);
+    CppSQLite3Statement();
 
-	CppSQLite3Statement(sqlite3* pDB, sqlite3_stmt* pVM);
+    CppSQLite3Statement(const CppSQLite3Statement& rStatement);
 
-	virtual ~CppSQLite3Statement();
+    CppSQLite3Statement(sqlite3* pDB, sqlite3_stmt* pVM);
 
-	CppSQLite3Statement& operator=(const CppSQLite3Statement& rStatement);
+    virtual ~CppSQLite3Statement();
 
-	int execDML();
+    CppSQLite3Statement& operator=(const CppSQLite3Statement& rStatement);
 
-	CppSQLite3Query execQuery();
+    int execDML();
 
-	void bind(int nParam, const char* szValue);
-	void bind(int nParam, const int nValue);
-	void bind(int nParam, const double dwValue);
-	void bind(int nParam, const unsigned char* blobValue, int nLen);
-	void bindNull(int nParam);
+    CppSQLite3Query execQuery();
 
-	int bindParameterIndex(const char* szParam);
-	void bind(const char* szParam, const char* szValue);
-	void bind(const char* szParam, const int nValue);
-	void bind(const char* szParam, const double dwValue);
-	void bind(const char* szParam, const unsigned char* blobValue, int nLen);
-	void bindNull(const char* szParam);
+    void bind(int nParam, const char* szValue);
+    void bind(int nParam, const int nValue);
+    void bind(int nParam, const long long nValue);
+    void bind(int nParam, const double dwValue);
+    void bind(int nParam, const unsigned char* blobValue, int nLen);
+    void bindNull(int nParam);
 
-	void reset();
+    void reset();
 
-	void finalize();
+    void finalize();
 
 private:
-	void checkDB();
-	void checkVM();
 
-	sqlite3* mpDB;
-	sqlite3_stmt* mpVM;
+    void checkDB() const;
+    void checkVM() const;
+
+    sqlite3* mpDB;
+    sqlite3_stmt* mpVM;
 };
 
 
-class CppSQLite3DB {
+class CppSQLite3DB
+{
 public:
-	CppSQLite3DB();
 
-	virtual ~CppSQLite3DB();
+    CppSQLite3DB();
 
-	void open(const char* szFile);
+    virtual ~CppSQLite3DB();
 
-	void close();
+    void open(const char* szFile);
 
-	bool tableExists(const char* szTable);
+    void close();
 
-	int execDML(const char* szSQL);
+    bool tableExists(const char* szTable);
 
-	CppSQLite3Query execQuery(const char* szSQL);
+    int execDML(const char* szSQL);
 
-	int execScalar(const char* szSQL, int nNullValue = 0);
+    CppSQLite3Query execQuery(const char* szSQL);
 
-	CppSQLite3Table getTable(const char* szSQL);
+    int execScalar(const char* szSQL);
 
-	CppSQLite3Statement compileStatement(const char* szSQL);
+    CppSQLite3Table getTable(const char* szSQL);
 
-	sqlite_int64 lastRowId();
+    CppSQLite3Statement compileStatement(const char* szSQL);
 
-	void interrupt() { sqlite3_interrupt(mpDB); }
+    sqlite_int64 lastRowId() const;
 
-	void setBusyTimeout(int nMillisecs);
+    void interrupt() { sqlite3_interrupt(mpDB); }
 
-	static const char* SQLiteVersion() { return SQLITE_VERSION; }
+    void setBusyTimeout(int nMillisecs);
 
-	static const char* SQLiteHeaderVersion() { return SQLITE_VERSION; }
-
-	static const char* SQLiteLibraryVersion() { return sqlite3_libversion(); }
-
-	static int SQLiteLibraryVersionNumber() { return sqlite3_libversion_number(); }
-
-	bool IsAutoCommitOn();
+    static const char* SQLiteVersion() { return SQLITE_VERSION; }
 
 private:
-	CppSQLite3DB(const CppSQLite3DB& db);
-	CppSQLite3DB& operator=(const CppSQLite3DB& db);
 
-	sqlite3_stmt* compile(const char* szSQL);
+    CppSQLite3DB(const CppSQLite3DB& db);
+    CppSQLite3DB& operator=(const CppSQLite3DB& db);
 
-	void checkDB();
+    sqlite3_stmt* compile(const char* szSQL);
 
-	sqlite3* mpDB;
-	int mnBusyTimeoutMs;
+    void checkDB() const;
+
+    sqlite3* mpDB;
+    int mnBusyTimeoutMs;
 };
 
 #endif

--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -929,7 +929,7 @@ Database::GetTransaction(const uint32& transid, const uint32& accountid, Transac
 	}
 
 	if ((data.CountCategories() == 1) && strlen(data.MemoAt(0)) > 0)
-		data.SetMemo(data.MemoAt(0));
+		data.SetMemo(DeescapeIllegalCharacters(data.MemoAt(0)));
 
 	UNLOCK;
 	return true;

--- a/src/LICENSE
+++ b/src/LICENSE
@@ -1,0 +1,26 @@
+CppSQLite was originally developed by Rob Groves on CodeProject:
+ <http://www.codeproject.com/KB/database/CppSQLite.aspx>
+
+ Maintenance and updates are Copyright (C) 2011 NeoSmart Technologies
+ <http://neosmart.net/>
+
+ Original copyright information:
+ Copyright (C) 2004 Rob Groves. All Rights Reserved.
+ <rob.groves@btinternet.com>
+
+ Permission to use, copy, modify, and distribute this software and its
+ documentation for any purpose, without fee, and without a written
+ agreement, is hereby granted, provided that the above copyright notice,
+ this paragraph and the following two paragraphs appear in all copies,
+ modifications, and distributions.
+
+ IN NO EVENT SHALL THE AUTHOR BE LIABLE TO ANY PARTY FOR DIRECT,
+ INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST
+ PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ EVEN IF THE AUTHOR HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+ THE AUTHOR SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ PARTICULAR PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF
+ ANY, PROVIDED HEREUNDER IS PROVIDED "AS IS". THE AUTHOR HAS NO OBLIGATION
+ TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.

--- a/src/Locale.cpp
+++ b/src/Locale.cpp
@@ -11,6 +11,10 @@
 #include <time.h>
 #include "App.h"
 #include "CBLocale.h"
+#include <Catalog.h>
+
+#undef B_TRANSLATION_CONTEXT
+#define B_TRANSLATION_CONTEXT "Locale"
 
 Locale::Locale(void)
 {
@@ -802,13 +806,14 @@ void
 ShowBug(const char* string)
 {
 	BString message =
-		"CapitalBe has run into a bug. This shouldn't happen, but it has.\n"
+		B_TRANSLATE("CapitalBe has run into a bug. This shouldn't happen, but it has.\n"
 		"Would you like to:\n\n1) Have CapitalBe make an e-mail to send to Support\n"
 		"2) Save the bug to a text file for e-mailing later\n"
-		"3) Just quit and do nothing\n";
+		"3) Just quit and do nothing\n");
 
 	DAlert* alert =
-		new DAlert("Agh! Bug!", message.String(), "Make an E-mail", "Save to File", "Quit");
+		new DAlert(B_TRANSLATE("Agh! Bug!"), message.String(), B_TRANSLATE("Make an E-mail"),
+		B_TRANSLATE("Save to File"), B_TRANSLATE("Quit"));
 	int32 value = alert->Go();
 
 	if (value == 0) {

--- a/src/Locale.cpp
+++ b/src/Locale.cpp
@@ -1,20 +1,21 @@
+#include "App.h"
+#include "CBLocale.h"
 #include <AppFileInfo.h>
+#include <Catalog.h>
 #include <Debug.h>
-#include <E-mail.h>
 #include <File.h>
 #include <OS.h>
 #include <Roster.h>
 #include <String.h>
+#include <Url.h>
 #include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
-#include "App.h"
-#include "CBLocale.h"
-#include <Catalog.h>
 
 #undef B_TRANSLATION_CONTEXT
 #define B_TRANSLATION_CONTEXT "Locale"
+
 
 Locale::Locale(void)
 {
@@ -805,18 +806,17 @@ GetVersionString(BString& string)
 void
 ShowBug(const char* string)
 {
-	BString message =
-		B_TRANSLATE("CapitalBe has run into a bug. This shouldn't happen, but it has.\n"
-		"Would you like to:\n\n1) Have CapitalBe make an e-mail to send to Support\n"
-		"2) Save the bug to a text file for e-mailing later\n"
-		"3) Just quit and do nothing\n");
+	BString message = B_TRANSLATE(
+		"CapitalBe has run into a bug. This shouldn't happen, but it has.\n"
+		"Would you like to:\n\n1) Save the bug to a text file for uploading to\n"
+		"CapitalBe's issue tracker (https://github.com/HaikuArchives/CapitalBe/issues)\n\n"
+		"2) Just quit and do nothing\n");
 
-	DAlert* alert =
-		new DAlert(B_TRANSLATE("Agh! Bug!"), message.String(), B_TRANSLATE("Make an E-mail"),
-		B_TRANSLATE("Save to File"), B_TRANSLATE("Quit"));
+	DAlert* alert = new DAlert(B_TRANSLATE("Agh! Bug!"), message.String(),
+		B_TRANSLATE("Save bugreport"), B_TRANSLATE("Quit"));
 	int32 value = alert->Go();
 
-	if (value == 0) {
+	if (value == 1) {
 		be_app->PostMessage(M_QUIT_NOW);
 		return;
 	}
@@ -830,19 +830,15 @@ ShowBug(const char* string)
 	message << "Error: " << string << "\n";
 
 	if (value == 0) {
-		// Make an e-mail to myself. :D
-
-		BString cmdstring("/boot/beos/apps/BeMail mailto:support@capitalbe.com ");
-		cmdstring << "-subject 'CapitalBe Bug Report' -body '" << message << "'";
-		cmdstring << " &";
-		system(cmdstring.String());
-	} else if (value == 1) {
 		// Generate a text file of the bug on the Desktop
 		BString filename("/boot/home/Desktop/CapitalBe Bug Report ");
 		filename << real_time_clock() << ".txt";
 		BFile file(filename.String(), B_READ_WRITE | B_CREATE_FILE | B_ERASE_FILE);
 		file.Write(message.String(), message.Length());
 		file.Unset();
+
+		// Open GitHub in browser
+		BUrl("https://github.com/HaikuArchives/CapitalBe/issues/").OpenWithPreferredApplication();
 	}
 
 	be_app->PostMessage(M_QUIT_NOW);

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -9,6 +9,7 @@
 #include <NetPositive.h>
 #include <Path.h>
 #include <Roster.h>
+#include <Url.h>
 #include <private/interface/AboutWindow.h>
 
 #include <stdlib.h>
@@ -239,8 +240,8 @@ MainWindow::MessageReceived(BMessage* msg)
 	switch (msg->what) {
 		case M_REPORT_BUG:
 		{
-			char* argv[2] = {(char*)"https://github.com/HaikuArchives/CapitalBe", NULL};
-			be_roster->Launch("text/html", 1, argv);
+			BUrl("https://github.com/HaikuArchives/CapitalBe/issues/")
+				.OpenWithPreferredApplication();
 			break;
 		}
 		case M_SHOW_NEW_ACCOUNT:


### PR DESCRIPTION
This PR fixes a problem with escaped characters in transaction memos. Fixes #7 
I've also included an updated version of the CppSQLite3 library from https://github.com/neosmart/CppSQLite. The previous version caused some non-fatal warnings during the build process. I haven't seen any issues with this change.

In addition, some missing strings where added for translation, as mentioned in `ToDo_Spanish`. Maybe this program can be added to Polyglot at some point for additional translations? 

Note that the bug report message (`CapitalBe has run into a bug`)  is translatable, but not the actual bug report that will be saved and possibly sent to a developer.