### PR TITLE
Improved support for multiple currencies

### DIFF
--- a/locales/en.catkeys
+++ b/locales/en.catkeys
@@ -1,4 +1,4 @@
-1	English	application/x-vnd.wgp-CapitalBe	2426942269
+1	English	application/x-vnd.wgp-CapitalBe	2699911572
 Year	ReportWindow		Year
 Edit transaction	TransactionEditWindow		Edit transaction
 None	ReportWindow		None
@@ -158,6 +158,7 @@ Total:	SplitView		Total:
 Unlimited	ScheduleListWindow		Unlimited
 Account settings	AccountSettingsWindow		Account settings
 Account name:	AccountSettingsWindow		Account name:
+Balance	QuickTrackerItem		Balance
 Set all to zero	BudgetWindow		Set all to zero
 When the split items are added together, they need to add up to %%ENTERED_AMOUNT%%. Currently, they add up to %%TOTAL_AMOUNT%%	SplitView		When the split items are added together, they need to add up to %%ENTERED_AMOUNT%%. Currently, they add up to %%TOTAL_AMOUNT%%
 Date is missing.	ReconcileWindow		Date is missing.
@@ -178,6 +179,7 @@ Not transferring any money	TransferWindow		Not transferring any money
 Split	CategoryWindow		Split
 Income	ReportWindow		Income
 Memo	SplitView		Memo
+<No accounts>	QuickTrackerItem		<No accounts>
 Total checks:	ReconcileWindow		Total checks:
 Not enough accounts for a transfer.	MainWindow		Not enough accounts for a transfer.
 Amount	TransactionReport		Amount
@@ -200,9 +202,9 @@ You can schedule transfers, deposits, or ATM transactions.	MainWindow		You can s
 Success!	ReconcileWindow		Success!
 Income	CategoryWindow		Income
 Edit category	CategoryWindow		Edit category
+Schedule transaction	ScheduleAddWindow		Schedule transaction
 Do you want to add this transaction without a category?	CategoryBox		Do you want to add this transaction without a category?
 QuickTracker	RegisterView		QuickTracker
-Schedule transaction	ScheduleAddWindow		Schedule transaction
 Type: %s	ScheduleAddWindow		Type: %s
 Weekly	Budget		Weekly
 Split	SplitFilterView		Split

--- a/src/Account.cpp
+++ b/src/Account.cpp
@@ -58,10 +58,8 @@ Account::Balance(void)
 	CppSQLite3Query query = gDatabase.DBQuery(command.String(), "Account::Balance");
 
 	int64 amount = 0;
-	if (query.eof())
-		return Fixed();
-
-	amount = query.getInt64Field(0);
+	if (!query.eof())
+		amount = query.getInt64Field(0);
 
 	Fixed f;
 	f.SetPremultiplied(amount);
@@ -326,10 +324,15 @@ Account::UseDefaultLocale(const bool& usedefault)
 	if (fUseDefaultLocale) {
 		command = "delete from accountlocale where accountid = ";
 		command << fID << ";";
+		gDatabase.DBCommand(command.String(), "Account::UseDefaultLocale");
 	} else {
 		// update the local copy in case it changed since the program was opened
 		fLocale = gDefaultLocale;
 
 		gDatabase.SetAccountLocale(fID, fLocale);
 	}
+
+	BMessage msg;
+	msg.AddPointer("item", this);
+	Notify(WATCH_ACCOUNT | WATCH_LOCALE | WATCH_CHANGE, &msg);
 }

--- a/src/Account.cpp
+++ b/src/Account.cpp
@@ -325,6 +325,7 @@ Account::UseDefaultLocale(const bool& usedefault)
 		command = "delete from accountlocale where accountid = ";
 		command << fID << ";";
 		gDatabase.DBCommand(command.String(), "Account::UseDefaultLocale");
+		gCurrentLocale = gDefaultLocale;
 	} else {
 		// update the local copy in case it changed since the program was opened
 		fLocale = gDefaultLocale;

--- a/src/AccountSettingsWindow.cpp
+++ b/src/AccountSettingsWindow.cpp
@@ -83,20 +83,24 @@ AccountSettingsWindow::MessageReceived(BMessage* msg)
 	switch (msg->what) {
 		case M_EDIT_ACCOUNT_SETTINGS:
 		{
-			Locale temp;
+			Locale customLocale;
+			Locale defaultLocale;
 
 			if (!fAccount) {
-				temp = gDefaultLocale;
-				fPrefView->GetSettings(temp);
-				gDatabase.AddAccount(fAccountName->Text(), ACCOUNT_BANK, "Open", &temp);
+				fPrefView->GetSettings(customLocale);
+				gDatabase.AddAccount(fAccountName->Text(), ACCOUNT_BANK, "Open",
+					defaultLocale == customLocale ? NULL : &customLocale);
 			} else {
 				if (strcmp(fAccountName->Text(), fAccount->Name()) != 0)
 					gDatabase.RenameAccount(fAccount, fAccountName->Text());
 
-				temp = fAccount->GetLocale();
-				fPrefView->GetSettings(temp);
-				if (temp != fAccount->GetLocale())
-					fAccount->SetLocale(temp);
+				fPrefView->GetSettings(customLocale);
+				if (fUseDefault->Value() != B_CONTROL_ON) {
+					fAccount->UseDefaultLocale(false);
+					fAccount->SetLocale(customLocale);
+				} else {
+					fAccount->UseDefaultLocale(true);
+				}
 			}
 
 			PostMessage(B_QUIT_REQUESTED);
@@ -110,9 +114,6 @@ AccountSettingsWindow::MessageReceived(BMessage* msg)
 				fPrefView->Hide();
 			else
 				fPrefView->Show();
-
-			if (fAccount != NULL)
-				fAccount->UseDefaultLocale(useDefault);
 
 			break;
 		}

--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -273,6 +273,7 @@ Database::SetCurrentAccount(const int32& index)
 	LOCK;
 	Account* acc = (Account*)fList.ItemAt(index);
 	fCurrent = acc;
+	gCurrentLocale = acc->GetLocale();
 
 	BMessage msg;
 	msg.AddPointer("item", (void*)acc);
@@ -299,6 +300,7 @@ Database::SetCurrentAccount(Account* account)
 
 	LOCK;
 	fCurrent = account;
+	gCurrentLocale = account->GetLocale();
 
 	BMessage msg;
 	msg.AddPointer("item", (void*)account);
@@ -544,6 +546,8 @@ Database::CountBudgetEntries(void)
 void
 Database::SetAccountLocale(const uint32& accountid, const Locale& data)
 {
+	gCurrentLocale = data;
+
 	LOCK;
 	BString command("select accountid from accountlocale where accountid = ");
 	command << accountid << ";";

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -184,9 +184,9 @@ MainWindow::MainWindow(BRect frame) : BWindow(frame, "", B_TITLED_WINDOW, 0)
 	fExportPanel->Window()->SetTitle(temp.String());
 	gDatabase.AddObserver(this);
 
-	HandleScheduledTransactions();
-
 	BLayoutBuilder::Group<>(this, B_VERTICAL, 0).SetInsets(0).Add(bar).Add(fRegisterView).End();
+
+	HandleScheduledTransactions();
 }
 
 MainWindow::~MainWindow(void)

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -254,9 +254,7 @@ MainWindow::MessageReceived(BMessage* msg)
 		case M_SHOW_NEW_ACCOUNT:
 		{
 			AccountSettingsWindow* newaccwin = new AccountSettingsWindow(NULL);
-			BRect r(Frame());
-			newaccwin->MoveTo(r.left + ((Bounds().Width() - newaccwin->Bounds().Width()) / 2),
-				r.top + ((Bounds().Height() - newaccwin->Bounds().Height()) / 2));
+			newaccwin->CenterIn(Frame());
 			newaccwin->Show();
 			break;
 		}
@@ -266,9 +264,7 @@ MainWindow::MessageReceived(BMessage* msg)
 				break;
 
 			AccountSettingsWindow* accwin = new AccountSettingsWindow(acc);
-			BRect r(Frame());
-			accwin->MoveTo(r.left + ((Bounds().Width() - accwin->Bounds().Width()) / 2),
-				r.top + ((Bounds().Height() - accwin->Bounds().Height()) / 2));
+			accwin->CenterIn(Frame());
 			accwin->Show();
 			break;
 		}
@@ -440,9 +436,7 @@ MainWindow::MessageReceived(BMessage* msg)
 			}
 
 			TransferWindow* tnwin = new TransferWindow(this);
-			BRect r(Frame());
-			tnwin->MoveTo(r.left + ((Bounds().Width() - tnwin->Bounds().Width()) / 2),
-				r.top + ((Bounds().Height() - tnwin->Bounds().Height()) / 2));
+			tnwin->CenterIn(Frame());
 			tnwin->Show();
 			break;
 		}
@@ -462,8 +456,7 @@ MainWindow::MessageReceived(BMessage* msg)
 			r.right = r.left + 400;
 			r.bottom = r.top + 300;
 			TransactionEditWindow* transwin = new TransactionEditWindow(r, data);
-			transwin->MoveTo(r.left + ((Bounds().Width() - transwin->Bounds().Width()) / 2),
-				r.top + ((Bounds().Height() - transwin->Bounds().Height()) / 2));
+			transwin->CenterIn(Frame());
 			transwin->Show();
 			break;
 		}
@@ -491,8 +484,7 @@ MainWindow::MessageReceived(BMessage* msg)
 			r.bottom = r.top + 300;
 
 			ScheduleAddWindow* schedwin = new ScheduleAddWindow(r, data);
-			schedwin->MoveTo(r.left + ((Bounds().Width() - schedwin->Bounds().Width()) / 2),
-				r.top + ((Bounds().Height() - schedwin->Bounds().Height()) / 2));
+			schedwin->CenterIn(Frame());
 			schedwin->Show();
 			break;
 		}
@@ -536,10 +528,8 @@ MainWindow::MessageReceived(BMessage* msg)
 		}
 		case M_SHOW_SCHEDULED_WINDOW:
 		{
-			BRect r(Frame());
 			ScheduleListWindow* schedwin = new ScheduleListWindow(BRect(100, 100, 600, 425));
-			schedwin->MoveTo(r.left + ((Bounds().Width() - schedwin->Bounds().Width()) / 2),
-				r.top + ((Bounds().Height() - schedwin->Bounds().Height()) / 2));
+			schedwin->CenterIn(Frame());
 			schedwin->Show();
 			break;
 		}
@@ -551,10 +541,8 @@ MainWindow::MessageReceived(BMessage* msg)
 		}
 		case M_SHOW_CATEGORY_WINDOW:
 		{
-			BRect r(Frame());
 			CategoryWindow* catwin = new CategoryWindow(BRect(100, 100, 600, 425));
-			catwin->MoveTo(r.left + ((Bounds().Width() - catwin->Bounds().Width()) / 2),
-				r.top + ((Bounds().Height() - catwin->Bounds().Height()) / 2));
+			catwin->CenterIn(Frame());
 			catwin->Show();
 			break;
 		}

--- a/src/QuickTrackerItem.cpp
+++ b/src/QuickTrackerItem.cpp
@@ -6,6 +6,7 @@
 #include "Fixed.h"
 
 #include <Catalog.h>
+#include <vector>
 
 
 #undef B_TRANSLATION_CONTEXT
@@ -72,12 +73,13 @@ QTNetWorthItem::HandleNotify(const uint64& value, const BMessage* msg)
 			acc->AddObserver(this);
 		} else if (value & WATCH_DELETE) {
 			acc->RemoveObserver(this);
-			if (gDatabase.CountAccounts() == 1) {
+			Calculate();
+			if (gDatabase.CountAccounts() >= 1) {
 				if (Window())
 					Window()->Lock();
 
 				BString label, temp;
-				temp << B_TRANSLATE("Account total:") << " ";
+				temp << B_TRANSLATE("Balance") << " (" << gDefaultLocale.CurrencySymbol() << "): ";
 				if (gCurrentLocale.CurrencyToString(Fixed(), label) == B_OK)
 					temp << label;
 				SetText(temp.String());
@@ -95,37 +97,85 @@ QTNetWorthItem::HandleNotify(const uint64& value, const BMessage* msg)
 void
 QTNetWorthItem::Calculate(void)
 {
-	BString label, temp;
+	BString balanceText, balanceLabel;
 	Fixed balance;
 
-	temp << B_TRANSLATE("Account total:") << " ";
-
-	if (gDatabase.CountAccounts() == 0) {
+	if (gDatabase.CountAccounts() == 0) { // No accounts
 		if (Window())
 			Window()->Lock();
 
-		if (gCurrentLocale.CurrencyToString(balance, label) == B_OK)
-			temp << " \n" << label;
+		if (gCurrentLocale.CurrencyToString(balance, balanceText) == B_OK)
+			balanceLabel = B_TRANSLATE("<No accounts>");
 
-		SetText(temp.String());
+		SetText(balanceLabel.String());
 
 		if (Window())
 			Window()->Unlock();
 		return;
 	}
 
-	for (int32 i = 0; i < gDatabase.CountAccounts(); i++) {
-		Account* account = gDatabase.AccountAt(i);
-		if (!account->IsClosed())
-			balance += account->Balance();
+	BString command;
+	std::vector<BString> currencies;
+	BString currency;
+	CppSQLite3Query query;
+
+
+	// Get list of currencies
+	command = "SELECT DISTINCT currencysymbol FROM accountlocale";
+	query = gDatabase.DBQuery(command.String(), "Database::Calculate");
+
+	while (!query.eof()) {
+		currency = query.getStringField(0);
+		currencies.push_back(currency);
+		query.nextRow();
 	}
 
-	if (gDefaultLocale.CurrencyToString(balance, label) == B_OK) {
-		temp << " \n" << label;
+	// Get sum of default currency accounts that are open:
+	command = "SELECT a.accountid FROM accountlist AS a LEFT JOIN accountlocale AS al ON "
+			  "a.accountid = al.accountid WHERE al.accountid IS NULL AND a.status = \"Open\";";
+	query = gDatabase.DBQuery(command.String(), "Database::Calculate");
 
+	balance = 0;
+	bool accountsFound = false;
+	while (!query.eof()) {
+		accountsFound = true;
+		Account* account = gDatabase.AccountAt(query.getIntField(0));
+		balance += account->Balance();
+		query.nextRow();
+	}
+
+	if (accountsFound && gDefaultLocale.CurrencyToString(balance, balanceText) == B_OK) {
+		balanceLabel << B_TRANSLATE("Balance") << " (" << gDefaultLocale.CurrencySymbol()
+					 << "): " << balanceText << "\n";
+	}
+
+	// Get sum of other currency accounts:
+	for (int32 i = 0; i < currencies.size(); i++) {
+		command = "SELECT a1.accountid FROM accountlist AS a1 JOIN accountlocale AS a2 ON "
+				  "a1.accountid=a2.accountid WHERE a2.currencysymbol = \"";
+		command << currencies.at(i) << "\" AND a1.status = \"Open\";";
+		query = gDatabase.DBQuery(command.String(), "Database::Calculate");
+
+		balance = 0;
+		Locale accLocale;
+
+		while (!query.eof()) {
+			Account* account = gDatabase.AccountAt(query.getIntField(0));
+			balance += account->Balance();
+			accLocale = account->GetLocale();
+			query.nextRow();
+		}
+
+		if (accLocale.CurrencyToString(balance, balanceText) == B_OK) {
+			balanceLabel << B_TRANSLATE("Balance") << " (" << accLocale.CurrencySymbol()
+						 << "): " << balanceText << "\n";
+		}
+	}
+
+	if (gDefaultLocale.CurrencyToString(balance, balanceText) == B_OK) {
 		if (Window()) {
 			Window()->Lock();
-			SetText(label.String());
+			SetText(balanceLabel.String());
 			Invalidate();
 			Window()->Unlock();
 		}


### PR DESCRIPTION
This PR fixes some issues where custom currency settings where lost when closing the app. In addition, QuickTracker will show the total balance for each of the currencies, instead of adding them all.

- Custom currency settings are correctly saved
- Fixes #50 
- QuickTracker lists the balance per currency, not all combined
- Replaced custom window centering with CenterIn()

I'm not sure what the best way to list the QuickTracker information is, I opted for "Balance" followed by the currency symbol, but maybe there's another way that is more intuitive?

![capitalBe](https://github.com/HaikuArchives/CapitalBe/assets/12958546/9a544316-dd9e-4f49-aa4b-123a28e6f3f3)
