### PR TITLE
Disable editing on closed accounts

### DIFF
--- a/locales/en.catkeys
+++ b/locales/en.catkeys
@@ -1,4 +1,4 @@
-1	English	application/x-vnd.wgp-CapitalBe	2699911572
+1	English	application/x-vnd.wgp-CapitalBe	3952487706
 Year	ReportWindow		Year
 Edit transaction	TransactionEditWindow		Edit transaction
 None	ReportWindow		None
@@ -41,9 +41,11 @@ Category	SplitView		Category
 Transactions	ReportWindow		Transactions
 Date	ReconcileWindow		Date
 Budget:	QuickTrackerItem		Budget:
+This transaction belongs to a closed account and cannot be edited. Please reopen the account if you need to make changes.	MainWindow		This transaction belongs to a closed account and cannot be edited. Please reopen the account if you need to make changes.
 Couldn't quick balance.	ReconcileWindow		Couldn't quick balance.
 Total	BudgetWindow		Total
 Memo	TransactionReport		Memo
+Closed account	MainWindow		Closed account
 Enter	SplitView		Enter
 Category	CashFlowReport		Category
 Reports:	ReportWindow		Reports:
@@ -78,8 +80,8 @@ English	CheckView	Path to localized helpfiles. Only translate if available in yo
 Closed	AccountListItem		Closed
 CapitalBe didn't understand the amount for Bank Charges.	ReconcileWindow		CapitalBe didn't understand the amount for Bank Charges.
 Import	MainWindow		Import
-Interest earned	ReconcileWindow		Interest earned
 CapitalBe understands lots of different ways of entering dates. Apparently, this wasn't one of them. You'll need to change how you entered this date. Sorry.	ReportWindow		CapitalBe understands lots of different ways of entering dates. Apparently, this wasn't one of them. You'll need to change how you entered this date. Sorry.
+Interest earned	ReconcileWindow		Interest earned
 Could not import the data in the file %%FILENAME%%.	MainWindow		Could not import the data in the file %%FILENAME%%.
 Quit	Locale		Quit
 Once deleted, you will not be able to get back any data on this account.	MainWindow		Once deleted, you will not be able to get back any data on this account.
@@ -98,6 +100,7 @@ Really delete account?	MainWindow		Really delete account?
 DEP	ReconcileWindow		DEP
 Income	BudgetWindow		Income
 This really shouldn't happen, so you probably should e-mail support about this.	MainWindow		This really shouldn't happen, so you probably should e-mail support about this.
+Remove	ScheduleListWindow		Remove
 Quick balance	ReconcileWindow		Quick balance
 This happens when the kind of file is not supported, when the file's data is damaged, or when you feed it a recipe for quiche.	MainWindow		This happens when the kind of file is not supported, when the file's data is damaged, or when you feed it a recipe for quiche.
 Payments	ScheduleListWindow		Payments
@@ -196,7 +199,6 @@ Categories…	MainWindow		Categories…
 No Memo	TransactionItem		No Memo
 CapitalBe didn't understand the amount.	CurrencyBox		CapitalBe didn't understand the amount.
 Day, Month, Year	PrefWindow		Day, Month, Year
-Remove…	ScheduleListWindow		Remove…
 If you intend to transfer money, it will need to be an amount that is not zero.	TransferWindow		If you intend to transfer money, it will need to be an amount that is not zero.
 You can schedule transfers, deposits, or ATM transactions.	MainWindow		You can schedule transfers, deposits, or ATM transactions.
 Success!	ReconcileWindow		Success!
@@ -204,6 +206,7 @@ Income	CategoryWindow		Income
 Edit category	CategoryWindow		Edit category
 Schedule transaction	ScheduleAddWindow		Schedule transaction
 Do you want to add this transaction without a category?	CategoryBox		Do you want to add this transaction without a category?
+This account is closed, and the settings cannot be edited. Please reopen the account if you need to make changes.	MainWindow		This account is closed, and the settings cannot be edited. Please reopen the account if you need to make changes.
 QuickTracker	RegisterView		QuickTracker
 Type: %s	ScheduleAddWindow		Type: %s
 Weekly	Budget		Weekly
@@ -239,8 +242,8 @@ CapitalBe has run into a bug. This shouldn't happen, but it has.\nWould you like
 Amount	BudgetWindow		Amount
 Cancel	CategoryBox		Cancel
 Scheduled transactions	ScheduleListWindow		Scheduled transactions
-Agh! Bug!	Locale		Agh! Bug!
 Starting date:	ReportWindow		Starting date:
+Agh! Bug!	Locale		Agh! Bug!
 Starting balance	ReconcileWindow		Starting balance
 Quarterly	ScheduleAddWindow		Quarterly
 Amount	CashFlowReport		Amount
@@ -270,10 +273,11 @@ Total checks: %s	ReconcileWindow		Total checks: %s
 English	ReportWindow	Path to localized helpfiles. Only translate if available in your language.	English
 Quarterly	BudgetWindow		Quarterly
 Remove category	CategoryWindow		Remove category
+You cannot schedule transactions on a closed account.	MainWindow		You cannot schedule transactions on a closed account.
 Decimal:	PrefWindow		Decimal:
 Split	ScheduleAddWindow		Split
 Month, Day, Year	PrefWindow		Month, Day, Year
 You need to enter the date for the statement to Quick Balance.	ReconcileWindow		You need to enter the date for the statement to Quick Balance.
-Use default currency settings	AccountSettingsWindow		Use default currency settings
 CapitalBe didn't understand the date you entered.	ReportWindow		CapitalBe didn't understand the date you entered.
+Use default currency settings	AccountSettingsWindow		Use default currency settings
 Unknown	ScheduleListWindow		Unknown

--- a/src/CheckView.cpp
+++ b/src/CheckView.cpp
@@ -294,6 +294,8 @@ CheckView::HandleNotify(const uint64& value, const BMessage* msg)
 				}
 			}
 		}
+	} else if (value & WATCH_CHANGE) {
+		SetFieldsEnabled(!gDatabase.CurrentAccount()->IsClosed());
 	}
 }
 
@@ -355,4 +357,18 @@ CheckView::DoNextField(void)
 		// We should *never* be here
 		ShowBug("M_NEXT_FIELD received for unknown view in CheckView");
 	}
+}
+
+
+void
+CheckView::SetFieldsEnabled(bool enabled)
+{
+	fDate->SetEnabled(enabled);
+	fDate->MakeFocus(enabled);
+	fType->SetEnabled(enabled);
+	fPayee->SetEnabled(enabled);
+	fAmount->SetEnabled(enabled);
+	fCategory->SetEnabled(enabled);
+	fMemo->SetEnabled(enabled);
+	fEnter->SetEnabled(enabled);
 }

--- a/src/CheckView.h
+++ b/src/CheckView.h
@@ -43,6 +43,7 @@ public:
 	void MakeEmpty(void);
 	void MakeFocus(bool value = true);
 	void FrameResized(float width, float height);
+	void SetFieldsEnabled(bool enabled);
 
 private:
 	void DoNextField(void);

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -148,7 +148,7 @@ MainWindow::MainWindow(BRect frame)
 		B_TRANSLATE("Enter a transfer" B_UTF8_ELLIPSIS), new BMessage(M_ENTER_TRANSFER), 'T'));
 	menu->AddSeparatorItem();
 	menu->AddItem(
-		new BMenuItem(B_TRANSLATE("Delete" B_UTF8_ELLIPSIS), new BMessage(M_DELETE_TRANSACTION)));
+		new BMenuItem(B_TRANSLATE("Delete"), new BMessage(M_DELETE_TRANSACTION)));
 	menu->AddSeparatorItem();
 	menu->AddItem(new BMenuItem(B_TRANSLATE("Schedule this transaction" B_UTF8_ELLIPSIS),
 		new BMessage(M_SCHEDULE_TRANSACTION)));
@@ -263,6 +263,14 @@ MainWindow::MessageReceived(BMessage* msg)
 		{
 			if (!acc)
 				break;
+
+			if (acc->IsClosed()) {
+				ShowAlert(B_TRANSLATE("Closed account"),
+					B_TRANSLATE("This account is closed, and the settings cannot be edited. Please "
+								"reopen the account if you need to make changes."),
+					B_WARNING_ALERT);
+				break;
+			}
 
 			AccountSettingsWindow* accwin = new AccountSettingsWindow(acc);
 			accwin->CenterIn(Frame());
@@ -451,6 +459,14 @@ MainWindow::MessageReceived(BMessage* msg)
 					break;
 			}
 
+			if (acc->IsClosed()) {
+				ShowAlert(B_TRANSLATE("Closed account"),
+					B_TRANSLATE("This transaction belongs to a closed account and cannot be "
+								"edited. Please reopen the account if you need to make changes."),
+					B_WARNING_ALERT);
+				break;
+			}
+
 			TransactionData data;
 			gDatabase.GetTransaction(acc->CurrentTransaction(), data);
 			BRect r(Frame());
@@ -469,6 +485,13 @@ MainWindow::MessageReceived(BMessage* msg)
 			if (!acc->CurrentTransaction()) {
 				if (!acc->CountTransactions())
 					break;
+			}
+
+			if (acc->IsClosed()) {
+				ShowAlert(B_TRANSLATE("Closed account"),
+					B_TRANSLATE("You cannot schedule transactions on a closed account."),
+					B_WARNING_ALERT);
+				break;
 			}
 
 			TransactionData data;

--- a/src/RegisterView.cpp
+++ b/src/RegisterView.cpp
@@ -110,6 +110,8 @@ RegisterView::MessageReceived(BMessage* msg)
 			if (fAccountView->CurrentSelection() < 0)
 				break;
 			gDatabase.SetCurrentAccount(fAccountView->CurrentSelection());
+			fCheckView->SetFieldsEnabled(!gDatabase.CurrentAccount()->IsClosed());
+
 			break;
 		}
 		case M_SHOW_ACCOUNT_SETTINGS:

--- a/src/ScheduleListWindow.cpp
+++ b/src/ScheduleListWindow.cpp
@@ -55,7 +55,7 @@ ScheduleListView::ScheduleListView(const char* name, const int32& flags)
 {
 	// the buttons
 	fRemoveButton = new BButton(
-		"removebutton", B_TRANSLATE("Remove" B_UTF8_ELLIPSIS), new BMessage(M_REMOVE_ITEM));
+		"removebutton", B_TRANSLATE("Remove"), new BMessage(M_REMOVE_ITEM));
 
 	// the transaction list
 	fListView = new BColumnListView("listview", B_FANCY_BORDER);

--- a/src/TransferWindow.cpp
+++ b/src/TransferWindow.cpp
@@ -100,7 +100,7 @@ TransferWindow::InitObject(Account* src, Account* dest, const Fixed& amount)
 	int32 current = -1;
 	for (int32 i = 0; i < gDatabase.CountAccounts(); i++) {
 		Account* acc = gDatabase.AccountAt(i);
-		if (acc) {
+		if (acc && !acc->IsClosed()) {
 			fSourceList->AddItem(new AccountListItem(acc));
 			fDestList->AddItem(new AccountListItem(acc));
 			if (acc == gDatabase.CurrentAccount())


### PR DESCRIPTION
This fixes #51 , by disabling the fields for entering transactions if the account is closed.
Double-click on a transaction for editing will show a warning message. 

![image](https://github.com/HaikuArchives/CapitalBe/assets/12958546/8d888837-369d-46bf-840e-5a5fb801e5e3)
