### PR TITLE
Fine tuning some GUI strings

### DIFF
--- a/locales/en.catkeys
+++ b/locales/en.catkeys
@@ -1,9 +1,8 @@
-1	English	application/x-vnd.wgp-CapitalBe	3952487706
+1	English	application/x-vnd.wgp-CapitalBe	2081549796
 Year	ReportWindow		Year
 Edit transaction	TransactionEditWindow		Edit transaction
 None	ReportWindow		None
 Export to QIF file…	MainWindow		Export to QIF file…
-Transfer from %%PAYEE%%	MainWindow		Transfer from %%PAYEE%%
 Reports	ReportWindow		Reports
 Monthly	ScheduleAddWindow		Monthly
 Annually	BudgetWindow		Annually
@@ -14,9 +13,12 @@ Category	CheckView		Category
 Cancel	TransferWindow		Cancel
 Weekly	BudgetWindow		Weekly
 Enter	CheckView		Enter
+This really shouldn't happen, so you probably should report a bug for this.	MainWindow		This really shouldn't happen, so you probably should report a bug for this.
 Next	MainWindow		Next
 Remove…	CategoryWindow		Remove…
 Cancel	CategoryWindow		Cancel
+Transfer from '%%PAYEE%%'	MainWindow		Transfer from '%%PAYEE%%'
+You need to enter the date for the statement to 'Quick balance'.	ReconcileWindow		You need to enter the date for the statement to 'Quick balance'.
 Amount	BudgetReport		Amount
 Cancel	ScheduleAddWindow		Cancel
 Payee: %s	ScheduleAddWindow		Payee: %s
@@ -26,9 +28,9 @@ Import from QIF file…	MainWindow		Import from QIF file…
 Ending date:	ReportWindow		Ending date:
 You need to enter a payee.	PayeeBox		You need to enter a payee.
 Split	ScheduledTransItem		Split
-Could not export your financial data to the file %%FILENAME%%.	MainWindow		Could not export your financial data to the file %%FILENAME%%.
 Separator:	PrefWindow		Separator:
 Bank charges	ReconcileWindow		Bank charges
+Transfer to '%%PAYEE%%'	MainWindow		Transfer to '%%PAYEE%%'
 CapitalBe uses the words 'Income','Spending', and 'Split' for managing categories, so you can't use them as category names. Please choose a different name for your new category.	CategoryWindow		CapitalBe uses the words 'Income','Spending', and 'Split' for managing categories, so you can't use them as category names. Please choose a different name for your new category.
 Total charges: %s	ReconcileWindow		Total charges: %s
 CapitalBe:	MainWindow		CapitalBe:
@@ -37,10 +39,12 @@ You need to select an account in order to reconcile it.	MainWindow		You need to 
 Spending category	CategoryWindow		Spending category
 Add…	CategoryWindow		Add…
 Total	NetWorthReport		Total
+Could not import the data in the file '%%FILENAME%%'.	MainWindow		Could not import the data in the file '%%FILENAME%%'.
 Category	SplitView		Category
 Transactions	ReportWindow		Transactions
 Date	ReconcileWindow		Date
 Budget:	QuickTrackerItem		Budget:
+Add item	SplitView		Add item
 This transaction belongs to a closed account and cannot be edited. Please reopen the account if you need to make changes.	MainWindow		This transaction belongs to a closed account and cannot be edited. Please reopen the account if you need to make changes.
 Couldn't quick balance.	ReconcileWindow		Couldn't quick balance.
 Total	BudgetWindow		Total
@@ -66,7 +70,6 @@ Add	CategoryBox		Add
 Cancel	ReconcileWindow		Cancel
 Category	TransactionReport		Category
 Amount	ScheduleListWindow		Amount
-Add Category	CategoryWindow		Add Category
 Spending	CategoryWindow		Spending
 There may be a typo or the wrong kind of currency symbol for this account.	SplitView		There may be a typo or the wrong kind of currency symbol for this account.
 Reconcile…	MainWindow		Reconcile…
@@ -78,13 +81,12 @@ Annually	ScheduleAddWindow		Annually
 Close	MainWindow		Close
 English	CheckView	Path to localized helpfiles. Only translate if available in your language.	English
 Closed	AccountListItem		Closed
-CapitalBe didn't understand the amount for Bank Charges.	ReconcileWindow		CapitalBe didn't understand the amount for Bank Charges.
 Import	MainWindow		Import
 CapitalBe understands lots of different ways of entering dates. Apparently, this wasn't one of them. You'll need to change how you entered this date. Sorry.	ReportWindow		CapitalBe understands lots of different ways of entering dates. Apparently, this wasn't one of them. You'll need to change how you entered this date. Sorry.
 Interest earned	ReconcileWindow		Interest earned
-Could not import the data in the file %%FILENAME%%.	MainWindow		Could not import the data in the file %%FILENAME%%.
 Quit	Locale		Quit
 Once deleted, you will not be able to get back any data on this account.	MainWindow		Once deleted, you will not be able to get back any data on this account.
+Add category	CategoryWindow		Add category
 Total deposits: %s	ReconcileWindow		Total deposits: %s
 Save bugreport	Locale		Save bugreport
 Amount	CheckView		Amount
@@ -99,13 +101,11 @@ Payee	CheckView		Payee
 Really delete account?	MainWindow		Really delete account?
 DEP	ReconcileWindow		DEP
 Income	BudgetWindow		Income
-This really shouldn't happen, so you probably should e-mail support about this.	MainWindow		This really shouldn't happen, so you probably should e-mail support about this.
 Remove	ScheduleListWindow		Remove
 Quick balance	ReconcileWindow		Quick balance
 This happens when the kind of file is not supported, when the file's data is damaged, or when you feed it a recipe for quiche.	MainWindow		This happens when the kind of file is not supported, when the file's data is damaged, or when you feed it a recipe for quiche.
 Payments	ScheduleListWindow		Payments
 Month	ReportWindow		Month
-Add Item	SplitView		Add Item
 Scheduled transactions…	MainWindow		Scheduled transactions…
 Delete	MainWindow		Delete
 Date format: %s	PrefWindow		Date format: %s
@@ -115,17 +115,17 @@ Quarter	ReportWindow		Quarter
 Account interest	ReconcileWindow		Account interest
 Schedule this transaction…	MainWindow		Schedule this transaction…
 Payee	ScheduleListWindow		Payee
+Name:	CategoryWindow		Name:
 Symbol:	PrefWindow		Symbol:
 Transactions	TransactionReport		Transactions
-No Memo	ScheduledTransItem		No Memo
 English	ScheduleListWindow	Path to localized helpfiles. Only translate if available in your language.	English
-Split Transaction	SplitView		Split Transaction
 Average	BudgetWindow		Average
 Quarterly	Budget		Quarterly
 Currency	PrefWindow		Currency
 Summary	BudgetWindow		Summary
 Ending balance	ReconcileWindow		Ending balance
 Frequency	ScheduleAddWindow		Frequency
+Name:	AccountSettingsWindow		Name:
 Category	BudgetReport		Category
 Accounts:	ReportWindow		Accounts:
 Options	PrefWindow		Options
@@ -134,17 +134,19 @@ Edit category	BudgetWindow		Edit category
 Reconcile	ReconcileWindow		Reconcile
 Weekly	ScheduleListWindow		Weekly
 Amount	SplitView		Amount
+Please choose a new category for all transactions currently in the '%%CATEGORY_NAME%%' category.	CategoryWindow		Please choose a new category for all transactions currently in the '%%CATEGORY_NAME%%' category.
 Reset	ReconcileWindow		Reset
 Frequency:	ScheduleAddWindow		Frequency:
 Category:	ScheduleAddWindow		Category:
 OK	AccountSettingsWindow		OK
 About CapitalBe	MainWindow		About CapitalBe
+No memo	ScheduledTransItem		No memo
 Annually	Budget		Annually
 Payee	SplitView		Payee
 Can't use this category name	CategoryWindow		Can't use this category name
 Budget	BudgetWindow		Budget
 Monthly	BudgetWindow		Monthly
-Transfer to %%PAYEE%%	MainWindow		Transfer to %%PAYEE%%
+CapitalBe didn't understand the amount for 'Interest earned'.	ReconcileWindow		CapitalBe didn't understand the amount for 'Interest earned'.
 OK	TransferWindow		OK
 Total worth	NetWorthReport		Total worth
 Memo	CheckView		Memo
@@ -160,7 +162,6 @@ Help	HelpButton		Help
 Total:	SplitView		Total:
 Unlimited	ScheduleListWindow		Unlimited
 Account settings	AccountSettingsWindow		Account settings
-Account name:	AccountSettingsWindow		Account name:
 Balance	QuickTrackerItem		Balance
 Set all to zero	BudgetWindow		Set all to zero
 When the split items are added together, they need to add up to %%ENTERED_AMOUNT%%. Currently, they add up to %%TOTAL_AMOUNT%%	SplitView		When the split items are added together, they need to add up to %%ENTERED_AMOUNT%%. Currently, they add up to %%TOTAL_AMOUNT%%
@@ -169,6 +170,7 @@ Numbered transactions cannot be scheduled.	MainWindow		Numbered transactions can
 New…	MainWindow		New…
 English	ReconcileWindow	Path to localized helpfiles. Only translate if available in your language.	English
 Quick Balance failed. This doesn't mean that you did something wrong - it's just that Quick Balance works on simpler cases in balancing an account than this one. Sorry.	ReconcileWindow		Quick Balance failed. This doesn't mean that you did something wrong - it's just that Quick Balance works on simpler cases in balancing an account than this one. Sorry.
+Show split	SplitView		Show split
 Amount: %s	ScheduleAddWindow		Amount: %s
 Transfer	BudgetWindow		Transfer
 Amount:	BudgetWindow		Amount:
@@ -184,6 +186,7 @@ Income	ReportWindow		Income
 Memo	SplitView		Memo
 <No accounts>	QuickTrackerItem		<No accounts>
 Total checks:	ReconcileWindow		Total checks:
+Remove item	SplitView		Remove item
 Not enough accounts for a transfer.	MainWindow		Not enough accounts for a transfer.
 Amount	TransactionReport		Amount
 Transaction	MainWindow		Transaction
@@ -191,12 +194,12 @@ Edit transfer	TransferWindow		Edit transfer
 Categories	CategoryWindow		Categories
 Reports	MainWindow		Reports
 Date	CheckView		Date
+CapitalBe didn't understand the amount for 'Bank charges'.	ReconcileWindow		CapitalBe didn't understand the amount for 'Bank charges'.
 Account	MainWindow		Account
 Currency format: %s	PrefWindow		Currency format: %s
 Payee	TransactionReport		Payee
 Total deposits:	ReconcileWindow		Total deposits:
 Categories…	MainWindow		Categories…
-No Memo	TransactionItem		No Memo
 CapitalBe didn't understand the amount.	CurrencyBox		CapitalBe didn't understand the amount.
 Day, Month, Year	PrefWindow		Day, Month, Year
 If you intend to transfer money, it will need to be an amount that is not zero.	TransferWindow		If you intend to transfer money, it will need to be an amount that is not zero.
@@ -209,6 +212,7 @@ Do you want to add this transaction without a category?	CategoryBox		Do you want
 This account is closed, and the settings cannot be edited. Please reopen the account if you need to make changes.	MainWindow		This account is closed, and the settings cannot be edited. Please reopen the account if you need to make changes.
 QuickTracker	RegisterView		QuickTracker
 Type: %s	ScheduleAddWindow		Type: %s
+New name:	CategoryWindow		New name:
 Weekly	Budget		Weekly
 Split	SplitFilterView		Split
 Bank charge	ReconcileWindow		Bank charge
@@ -220,8 +224,6 @@ Date	SplitView		Date
 Quit	MainWindow		Quit
 Lowest	BudgetWindow		Lowest
 Previous	MainWindow		Previous
-New category name:	CategoryWindow		New category name:
-Remove Item	SplitView		Remove Item
 Accounts	RegisterView		Accounts
 Payee is missing.	PayeeBox		Payee is missing.
 Type	CheckView		Type
@@ -234,7 +236,6 @@ Tools	MainWindow		Tools
 Transaction type is missing.	CheckNumBox		Transaction type is missing.
 Uncategorized	CategoryBox		Uncategorized
 Split	TransactionItem		Split
-CapitalBe didn't understand the amount for Interest Earned.	ReconcileWindow		CapitalBe didn't understand the amount for Interest Earned.
 Split	SplitView		Split
 The split total must match the amount box.	SplitView		The split total must match the amount box.
 Delete…	MainWindow		Delete…
@@ -242,20 +243,17 @@ CapitalBe has run into a bug. This shouldn't happen, but it has.\nWould you like
 Amount	BudgetWindow		Amount
 Cancel	CategoryBox		Cancel
 Scheduled transactions	ScheduleListWindow		Scheduled transactions
-Starting date:	ReportWindow		Starting date:
 Agh! Bug!	Locale		Agh! Bug!
+Starting date:	ReportWindow		Starting date:
 Starting balance	ReconcileWindow		Starting balance
 Quarterly	ScheduleAddWindow		Quarterly
 Amount	CashFlowReport		Amount
-Hide Split	SplitView		Hide Split
 Reconcile:	ReconcileWindow		Reconcile:
 Total charges:	ReconcileWindow		Total charges:
 Total worth	ReportWindow		Total worth
-Category name:	CategoryWindow		Category name:
 Expense	CashFlowReport		Expense
 No transactions	TransactionReport		No transactions
 Date:	TransferWindow		Date:
-Please choose a new category for all transactions currently in the %%CATEGORY_NAME%% category.	CategoryWindow		Please choose a new category for all transactions currently in the %%CATEGORY_NAME%% category.
 To account:	TransferWindow		To account:
 Add account transfer	TransferWindow		Add account transfer
 You need to have an account created in order to reconcile it.	MainWindow		You need to have an account created in order to reconcile it.
@@ -264,11 +262,13 @@ CapitalBe understands lots of different ways of entering dates. Apparently, this
 There may be a typo or the wrong kind of currency symbol for this account.	CurrencyBox		There may be a typo or the wrong kind of currency symbol for this account.
 Next Payment	ScheduleListWindow		Next Payment
 Type	SplitView		Type
-Bank Charge	ReconcileWindow		Bank Charge
 Recalculate all	BudgetWindow		Recalculate all
 Date	NetWorthReport		Date
 CapitalBe didn't understand the date you entered.	ScheduleAddWindow		CapitalBe didn't understand the date you entered.
 Income	CashFlowReport		Income
+Hide split	SplitView		Hide split
+Split transaction	SplitView		Split transaction
+Could not export your financial data to the file '%%FILENAME%%'.	MainWindow		Could not export your financial data to the file '%%FILENAME%%'.
 Total checks: %s	ReconcileWindow		Total checks: %s
 English	ReportWindow	Path to localized helpfiles. Only translate if available in your language.	English
 Quarterly	BudgetWindow		Quarterly
@@ -277,7 +277,7 @@ You cannot schedule transactions on a closed account.	MainWindow		You cannot sch
 Decimal:	PrefWindow		Decimal:
 Split	ScheduleAddWindow		Split
 Month, Day, Year	PrefWindow		Month, Day, Year
-You need to enter the date for the statement to Quick Balance.	ReconcileWindow		You need to enter the date for the statement to Quick Balance.
 CapitalBe didn't understand the date you entered.	ReportWindow		CapitalBe didn't understand the date you entered.
 Use default currency settings	AccountSettingsWindow		Use default currency settings
 Unknown	ScheduleListWindow		Unknown
+No memo	TransactionItem		No memo

--- a/src/AccountSettingsWindow.cpp
+++ b/src/AccountSettingsWindow.cpp
@@ -31,7 +31,7 @@ AccountSettingsWindow::AccountSettingsWindow(Account* account)
 	BView* back = new BView("back", B_WILL_DRAW);
 	back->SetViewUIColor(B_PANEL_BACKGROUND_COLOR);
 
-	fAccountName = new AutoTextControl("accname", B_TRANSLATE("Account name:"),
+	fAccountName = new AutoTextControl("accname", B_TRANSLATE("Name:"),
 		(fAccount ? fAccount->Name() : NULL), new BMessage(M_NAME_CHANGED));
 	fAccountName->SetCharacterLimit(32);
 

--- a/src/CategoryWindow.cpp
+++ b/src/CategoryWindow.cpp
@@ -204,7 +204,7 @@ CategoryView::MessageReceived(BMessage* msg)
 				name.ICompare(B_TRANSLATE("Spending")) == 0 ||
 				name.ICompare(B_TRANSLATE("Split")) == 0) {
 				ShowAlert(B_TRANSLATE("Can't use this category name"),
-					B_TRANSLATE("CapitalBe uses the words 'Income','Spending', and 'Split' "
+					B_TRANSLATE("CapitalBe uses the words 'Income', 'Spending', and 'Split' "
 								"for managing categories, so you can't use them as category names. "
 								"Please choose a different name for your new category."));
 				break;
@@ -346,7 +346,7 @@ CategoryItem::DrawItem(BView* owner, BRect frame, bool complete)
 
 
 CategoryInputWindow::CategoryInputWindow(const BRect& frame, BView* target)
-	: BWindow(frame, B_TRANSLATE("Add Category"), B_FLOATING_WINDOW_LOOK, B_MODAL_APP_WINDOW_FEEL,
+	: BWindow(frame, B_TRANSLATE("Add category"), B_FLOATING_WINDOW_LOOK, B_MODAL_APP_WINDOW_FEEL,
 		  B_ASYNCHRONOUS_CONTROLS | B_NOT_ZOOMABLE | B_NOT_MINIMIZABLE | B_NOT_V_RESIZABLE |
 			  B_AUTO_UPDATE_SIZE_LIMITS | B_CLOSE_ON_ESCAPE),
 	  fTarget(target)
@@ -357,7 +357,7 @@ CategoryInputWindow::CategoryInputWindow(const BRect& frame, BView* target)
 	BLayoutBuilder::Group<>(this, B_VERTICAL).SetInsets(0).Add(view).End();
 
 	fNameBox = new AutoTextControl(
-		"namebox", B_TRANSLATE("Category name:"), "", new BMessage(M_NAME_CHANGED));
+		"namebox", B_TRANSLATE("Name:"), "", new BMessage(M_NAME_CHANGED));
 	fNameBox->SetCharacterLimit(32);
 
 	fExpenseBox = new BCheckBox("expensebox", B_TRANSLATE("Spending category"), NULL);
@@ -432,7 +432,7 @@ CategoryRemoveWindow::CategoryRemoveWindow(const BRect& frame, const char* from,
 
 	BString directions(
 		B_TRANSLATE("Please choose a new category for all transactions currently in the "
-					"%%CATEGORY_NAME%% category."));
+					"'%%CATEGORY_NAME%%' category."));
 	directions.ReplaceFirst("%%CATEGORY_NAME%%", from);
 	fDirections->SetText(directions.String());
 	fDirections->SetViewUIColor(B_PANEL_BACKGROUND_COLOR);
@@ -545,12 +545,12 @@ CategoryEditWindow::CategoryEditWindow(const BRect& frame, const char* oldname, 
 	BView* view = new BView("background", B_WILL_DRAW | B_FRAME_EVENTS);
 	BLayoutBuilder::Group<>(this, B_VERTICAL).SetInsets(0).Add(view).End();
 
-	temp = B_TRANSLATE("Category name:");
+	temp = B_TRANSLATE("Name:");
 	temp << " " << fOldName;
 	BStringView* oldnameView = new BStringView("oldname", temp.String());
 
 	fNameBox = new AutoTextControl(
-		"namebox", B_TRANSLATE("New category name:"), "", new BMessage(M_NAME_CHANGED));
+		"namebox", B_TRANSLATE("New name:"), "", new BMessage(M_NAME_CHANGED));
 	fNameBox->SetCharacterLimit(32);
 
 	fOKButton = new BButton("okbutton", B_TRANSLATE("OK"), new BMessage(M_EDIT_CATEGORY));

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -345,7 +345,7 @@ MainWindow::MessageReceived(BMessage* msg)
 				break;
 
 			if (!gDatabase.ImportFile(ref)) {
-				BString errmsg(B_TRANSLATE("Could not import the data in the file %%FILENAME%%."));
+				BString errmsg(B_TRANSLATE("Could not import the data in the file '%%FILENAME%%'."));
 				errmsg.ReplaceFirst("%%FILENAME%%", ref.name);
 				ShowAlert(errmsg.String(),
 					B_TRANSLATE("This happens when the kind of file is not "
@@ -375,11 +375,11 @@ MainWindow::MessageReceived(BMessage* msg)
 
 			if (!gDatabase.ExportFile(dir)) {
 				BString errmsg(
-					B_TRANSLATE("Could not export your financial data to the file %%FILENAME%%."));
+					B_TRANSLATE("Could not export your financial data to the file '%%FILENAME%%'."));
 				errmsg.ReplaceFirst("%%FILENAME%%", dir.name);
 				ShowAlert(
 					errmsg.String(), B_TRANSLATE("This really shouldn't happen, so you probably "
-												 "should e-mail support about this."));
+												 "should report a bug for this."));
 			}
 			break;
 		}
@@ -617,7 +617,7 @@ MainWindow::CreateTransfer(BMessage* msg)
 
 	// Now that we've gathered all the data from the message sent to us by TransferWindow,
 	// we create the transactions needed for each account.
-	BString payee = B_TRANSLATE("Transfer to %%PAYEE%%");
+	BString payee = B_TRANSLATE("Transfer to '%%PAYEE%%'");
 	payee.ReplaceFirst("%%PAYEE%%", to->Name());
 
 	uint32 transid = gDatabase.NextTransactionID();
@@ -625,7 +625,7 @@ MainWindow::CreateTransfer(BMessage* msg)
 	gDatabase.AddTransaction(from->GetID(), transid, date, type, payee.String(),
 		fixed.InvertAsCopy(), "Transfer", memo.String());
 
-	payee = B_TRANSLATE("Transfer from %%PAYEE%%");
+	payee = B_TRANSLATE("Transfer from '%%PAYEE%%'");
 	payee.ReplaceFirst("%%PAYEE%%", to->Name());
 	payee << from->Name();
 	gDatabase.AddTransaction(

--- a/src/ReconcileWindow.cpp
+++ b/src/ReconcileWindow.cpp
@@ -562,7 +562,7 @@ ReconcileWindow::ApplyChargesAndInterest(void)
 	if (strlen(fCharges->Text()) > 0 &&
 		gCurrentLocale.StringToCurrency(fCharges->Text(), charge) == B_OK) {
 		TransactionData chargetrans(fAccount, fDate->Text(), "ATM", B_TRANSLATE("Bank charge"),
-			fCharges->Text(), B_TRANSLATE("Bank Charge"), NULL, TRANS_RECONCILED);
+			fCharges->Text(), B_TRANSLATE("Bank charge"), NULL, TRANS_RECONCILED);
 		gDatabase.AddTransaction(chargetrans);
 	}
 
@@ -592,7 +592,7 @@ ReconcileWindow::AutoReconcile(void)
 		// Do we have an empty date box?
 		if (strlen(fDate->Text()) < 1) {
 			ShowAlert(B_TRANSLATE("Date is missing."),
-				B_TRANSLATE("You need to enter the date for the statement to Quick Balance."));
+				B_TRANSLATE("You need to enter the date for the statement to 'Quick balance'."));
 			return false;
 		}
 	}
@@ -604,7 +604,7 @@ ReconcileWindow::AutoReconcile(void)
 		if (gCurrentLocale.StringToCurrency(fCharges->Text(), bankchrg) == B_OK)
 			bankchrg.Invert();
 		else {
-			ShowAlert(B_TRANSLATE("CapitalBe didn't understand the amount for Bank Charges."),
+			ShowAlert(B_TRANSLATE("CapitalBe didn't understand the amount for 'Bank charges'."),
 				B_TRANSLATE("There may be a typo or the wrong kind of currency symbol "
 							"for this account."));
 			return false;
@@ -613,7 +613,7 @@ ReconcileWindow::AutoReconcile(void)
 
 	if (strlen(fInterest->Text()) > 0) {
 		if (gCurrentLocale.StringToCurrency(fInterest->Text(), interest) != B_OK) {
-			ShowAlert(B_TRANSLATE("CapitalBe didn't understand the amount for Interest Earned."),
+			ShowAlert(B_TRANSLATE("CapitalBe didn't understand the amount for 'Interest earned'."),
 				B_TRANSLATE("There may be a typo or the wrong kind of currency symbol "
 							"for this account."));
 			return false;
@@ -664,9 +664,9 @@ ReconcileWindow::AutoReconcile(void)
 		return true;
 	}
 
-	ShowAlert(B_TRANSLATE("Couldn't quick balance."),
-		B_TRANSLATE("Quick Balance failed. This doesn't mean "
-					"that you did something wrong - it's just that Quick Balance works on "
+	ShowAlert(B_TRANSLATE("Couldn't Quick balance."),
+		B_TRANSLATE("Quick balance failed. This doesn't mean "
+					"that you did something wrong - it's just that 'Quick balance' works on "
 					"simpler cases in balancing an account than this one. Sorry."));
 	return false;
 }

--- a/src/ScheduledTransItem.cpp
+++ b/src/ScheduledTransItem.cpp
@@ -177,7 +177,7 @@ ScheduledTransItem::DrawItem(BView* owner, BRect frame, bool complete)
 		owner->DrawString(fMemo.String(), BPoint(xpos + 5, ypos - 3));
 	} else {
 		owner->SetHighUIColor(B_LIST_ITEM_TEXT_COLOR, GetMutedTint(CB_MUTED_TEXT));
-		owner->DrawString(B_TRANSLATE("No Memo"), BPoint(xpos + 5, ypos - 3));
+		owner->DrawString(B_TRANSLATE("No memo"), BPoint(xpos + 5, ypos - 3));
 	}
 	owner->ConstrainClippingRegion(NULL);
 }

--- a/src/SplitView.cpp
+++ b/src/SplitView.cpp
@@ -92,10 +92,10 @@ SplitView::SplitView(const char* name, const TransactionData& trans, const int32
 	fSplitContainer = new BView("splitcontainer", B_WILL_DRAW);
 	fSplitContainer->SetViewUIColor(B_PANEL_BACKGROUND_COLOR);
 
-	fAddSplit = new BButton("addsplit", B_TRANSLATE("Add Item"), new BMessage(M_ADD_SPLIT));
+	fAddSplit = new BButton("addsplit", B_TRANSLATE("Add item"), new BMessage(M_ADD_SPLIT));
 
 	fRemoveSplit =
-		new BButton("removesplit", B_TRANSLATE("Remove Item"), new BMessage(M_REMOVE_SPLIT));
+		new BButton("removesplit", B_TRANSLATE("Remove item"), new BMessage(M_REMOVE_SPLIT));
 
 	fSplitCategory = new BTextControl("splitcategory", NULL, NULL, NULL, B_WILL_DRAW);
 
@@ -138,7 +138,7 @@ SplitView::SplitView(const char* name, const TransactionData& trans, const int32
 
 	if (fTransaction.CountCategories() > 1 ||
 		strcmp(fTransaction.NameAt(0), B_TRANSLATE("Split")) == 0) {
-		fCategory->SetText(B_TRANSLATE("Split Transaction"));
+		fCategory->SetText(B_TRANSLATE("Split transaction"));
 		fStartExpanded = true;
 	}
 
@@ -687,7 +687,7 @@ void
 SplitView::ToggleSplit(void)
 {
 	if (fSplitContainer->IsHidden()) {
-		fSplit->SetLabel(B_TRANSLATE("Hide Split"));
+		fSplit->SetLabel(B_TRANSLATE("Hide split"));
 
 		fSplitContainer->Show();
 		fCategory->SetEnabled(false);
@@ -698,7 +698,7 @@ SplitView::ToggleSplit(void)
 		Invalidate();
 		fEnter->Invalidate();
 	} else {
-		fSplit->SetLabel(B_TRANSLATE("Show Split"));
+		fSplit->SetLabel(B_TRANSLATE("Show split"));
 
 		fSplitContainer->Hide();
 		fCategory->SetEnabled(true);

--- a/src/TransactionItem.cpp
+++ b/src/TransactionItem.cpp
@@ -185,7 +185,7 @@ TransactionItem::DrawItem(BView* owner, BRect frame, bool complete)
 		owner->DrawString(fMemo.String(), BPoint(xpos + 5, ypos - 6));
 	} else {
 		owner->SetHighUIColor(B_LIST_ITEM_TEXT_COLOR, GetMutedTint(CB_MUTED_TEXT));
-		owner->DrawString(B_TRANSLATE("No Memo"), BPoint(xpos + 5, ypos - 6));
+		owner->DrawString(B_TRANSLATE("No memo"), BPoint(xpos + 5, ypos - 6));
 	}
 	owner->ConstrainClippingRegion(NULL);
 }


### PR DESCRIPTION
* Sentence casing.

* When creating/editing an Account or Category, it's not needed to label the text control e.g. "New category name:", because the window title already says we're editing a category. This saves space, too.

* Put variables like %%FILENAME%% etc. in single quotes. Reads better when there are spaces in those names.

* Replaced one left "e-mail support" to "go report a bug".

* Update en.catkeys