### PR TITLE
Improve language strings

### DIFF
--- a/locales/en.catkeys
+++ b/locales/en.catkeys
@@ -1,14 +1,13 @@
-1	English	application/x-vnd.wgp-CapitalBe	2081549796
+1	English	application/x-vnd.wgp-CapitalBe	1737071390
 Year	ReportWindow		Year
-Edit transaction	TransactionEditWindow		Edit transaction
 None	ReportWindow		None
 Export to QIF file…	MainWindow		Export to QIF file…
 Reports	ReportWindow		Reports
 Monthly	ScheduleAddWindow		Monthly
 Annually	BudgetWindow		Annually
 Report a bug…	MainWindow		Report a bug…
+Category is missing	CategoryWindow		Category is missing
 OK	PrefWindow		OK
-CapitalBe didn't understand the date you entered.	DateBox		CapitalBe didn't understand the date you entered.
 Category	CheckView		Category
 Cancel	TransferWindow		Cancel
 Weekly	BudgetWindow		Weekly
@@ -19,54 +18,49 @@ Remove…	CategoryWindow		Remove…
 Cancel	CategoryWindow		Cancel
 Transfer from '%%PAYEE%%'	MainWindow		Transfer from '%%PAYEE%%'
 You need to enter the date for the statement to 'Quick balance'.	ReconcileWindow		You need to enter the date for the statement to 'Quick balance'.
-Amount	BudgetReport		Amount
 Cancel	ScheduleAddWindow		Cancel
 Payee: %s	ScheduleAddWindow		Payee: %s
 Default account settings:	PrefWindow		Default account settings:
+Account total	MainWindow		Account total
 CapitalBe	System name		CapitalBe
 Import from QIF file…	MainWindow		Import from QIF file…
 Ending date:	ReportWindow		Ending date:
-You need to enter a payee.	PayeeBox		You need to enter a payee.
 Split	ScheduledTransItem		Split
 Separator:	PrefWindow		Separator:
 Bank charges	ReconcileWindow		Bank charges
 Transfer to '%%PAYEE%%'	MainWindow		Transfer to '%%PAYEE%%'
-CapitalBe uses the words 'Income','Spending', and 'Split' for managing categories, so you can't use them as category names. Please choose a different name for your new category.	CategoryWindow		CapitalBe uses the words 'Income','Spending', and 'Split' for managing categories, so you can't use them as category names. Please choose a different name for your new category.
+Could not import the data in the file '%%FILENAME%%'	MainWindow		Could not import the data in the file '%%FILENAME%%'
 Total charges: %s	ReconcileWindow		Total charges: %s
-CapitalBe:	MainWindow		CapitalBe:
-CapitalBe didn't understand the amount.	SplitView		CapitalBe didn't understand the amount.
 You need to select an account in order to reconcile it.	MainWindow		You need to select an account in order to reconcile it.
 Spending category	CategoryWindow		Spending category
 Add…	CategoryWindow		Add…
 Total	NetWorthReport		Total
-Could not import the data in the file '%%FILENAME%%'.	MainWindow		Could not import the data in the file '%%FILENAME%%'.
 Category	SplitView		Category
 Transactions	ReportWindow		Transactions
 Date	ReconcileWindow		Date
-Budget:	QuickTrackerItem		Budget:
 Add item	SplitView		Add item
 This transaction belongs to a closed account and cannot be edited. Please reopen the account if you need to make changes.	MainWindow		This transaction belongs to a closed account and cannot be edited. Please reopen the account if you need to make changes.
-Couldn't quick balance.	ReconcileWindow		Couldn't quick balance.
+Help	MainWindow		Help
 Total	BudgetWindow		Total
 Memo	TransactionReport		Memo
+Edit transaction	TransactionEdit		Edit transaction
 Closed account	MainWindow		Closed account
 Enter	SplitView		Enter
 Category	CashFlowReport		Category
 Reports:	ReportWindow		Reports:
-Subtotal:	ReportWindow		Subtotal:
 CapitalBe understands lots of different ways of entering dates. Apparently, this wasn't one of them. You'll need to change how you entered this date. Sorry.	ScheduleAddWindow		CapitalBe understands lots of different ways of entering dates. Apparently, this wasn't one of them. You'll need to change how you entered this date. Sorry.
 Highest	BudgetWindow		Highest
-Unknown	Budget		Unknown
 You need to have at least 2 accounts to perform a transfer.	MainWindow		You need to have at least 2 accounts to perform a transfer.
 Monthly	ScheduleListWindow		Monthly
 Category	BudgetWindow		Category
 Frequency	BudgetWindow		Frequency
-Category is missing.	CategoryBox		Category is missing.
+CapitalBe didn't understand the amount for 'Bank charges'	ReconcileWindow		CapitalBe didn't understand the amount for 'Bank charges'
 Subtotal	ReportWindow		Subtotal
-Memo:	ScheduleAddWindow		Memo:
+You need to enter a check number or transaction type, such as ATM (for debit card transactions and the like), DEP (for deposits), or your own code for some other kind of expense.	CheckView		You need to enter a check number or transaction type, such as ATM (for debit card transactions and the like), DEP (for deposits), or your own code for some other kind of expense.
 Uncategorized	SplitView		Uncategorized
 Frequency	ScheduleListWindow		Frequency
-Add	CategoryBox		Add
+Split	TransactionEdit		Split
+CapitalBe understands lots of different ways of entering dates. Apparently, this wasn't one of them. You'll need to change how you entered this date. Sorry.	TextInput		CapitalBe understands lots of different ways of entering dates. Apparently, this wasn't one of them. You'll need to change how you entered this date. Sorry.
 Cancel	ReconcileWindow		Cancel
 Category	TransactionReport		Category
 Amount	ScheduleListWindow		Amount
@@ -80,22 +74,28 @@ Edit…	CategoryWindow		Edit…
 Annually	ScheduleAddWindow		Annually
 Close	MainWindow		Close
 English	CheckView	Path to localized helpfiles. Only translate if available in your language.	English
-Closed	AccountListItem		Closed
 Import	MainWindow		Import
-CapitalBe understands lots of different ways of entering dates. Apparently, this wasn't one of them. You'll need to change how you entered this date. Sorry.	ReportWindow		CapitalBe understands lots of different ways of entering dates. Apparently, this wasn't one of them. You'll need to change how you entered this date. Sorry.
 Interest earned	ReconcileWindow		Interest earned
+CapitalBe understands lots of different ways of entering dates. Apparently, this wasn't one of them. You'll need to change how you entered this date. Sorry.	ReportWindow		CapitalBe understands lots of different ways of entering dates. Apparently, this wasn't one of them. You'll need to change how you entered this date. Sorry.
 Quit	Locale		Quit
 Once deleted, you will not be able to get back any data on this account.	MainWindow		Once deleted, you will not be able to get back any data on this account.
 Add category	CategoryWindow		Add category
+Could not export your financial data to the file '%%FILENAME%%'	MainWindow		Could not export your financial data to the file '%%FILENAME%%'
+CapitalBe didn't understand the amount	SplitView		CapitalBe didn't understand the amount
+Name:	Account		Name:
 Total deposits: %s	ReconcileWindow		Total deposits: %s
 Save bugreport	Locale		Save bugreport
 Amount	CheckView		Amount
 Indefinitely	ScheduleAddWindow		Indefinitely
 Cancel	MainWindow		Cancel
+<No accounts>	MainWindow		<No accounts>
+There may be a typo or the wrong kind of currency symbol for this account.	TextInput		There may be a typo or the wrong kind of currency symbol for this account.
 Categories	ReportWindow		Categories
 Appears before amount	PrefWindow		Appears before amount
 Unreconciled total: %s	ReconcileWindow		Unreconciled total: %s
 Date	TransactionReport		Date
+CapitalBe didn't understand the date you entered	ScheduleAddWindow		CapitalBe didn't understand the date you entered
+Couldn't Quick balance	ReconcileWindow		Couldn't Quick balance
 There may be a typo or the wrong kind of currency symbol for this account.	ReconcileWindow		There may be a typo or the wrong kind of currency symbol for this account.
 Payee	CheckView		Payee
 Really delete account?	MainWindow		Really delete account?
@@ -106,6 +106,9 @@ Quick balance	ReconcileWindow		Quick balance
 This happens when the kind of file is not supported, when the file's data is damaged, or when you feed it a recipe for quiche.	MainWindow		This happens when the kind of file is not supported, when the file's data is damaged, or when you feed it a recipe for quiche.
 Payments	ScheduleListWindow		Payments
 Month	ReportWindow		Month
+No memo	TransactionEdit		No memo
+Closed	Account		Closed
+Memo	ScheduleAddWindow		Memo
 Scheduled transactions…	MainWindow		Scheduled transactions…
 Delete	MainWindow		Delete
 Date format: %s	PrefWindow		Date format: %s
@@ -119,34 +122,35 @@ Name:	CategoryWindow		Name:
 Symbol:	PrefWindow		Symbol:
 Transactions	TransactionReport		Transactions
 English	ScheduleListWindow	Path to localized helpfiles. Only translate if available in your language.	English
+CapitalBe didn't understand the amount	TextInput		CapitalBe didn't understand the amount
 Average	BudgetWindow		Average
-Quarterly	Budget		Quarterly
 Currency	PrefWindow		Currency
 Summary	BudgetWindow		Summary
+You need to enter a payee.	TextInput		You need to enter a payee.
 Ending balance	ReconcileWindow		Ending balance
+Category	ScheduleAddWindow		Category
 Frequency	ScheduleAddWindow		Frequency
-Name:	AccountSettingsWindow		Name:
-Category	BudgetReport		Category
 Accounts:	ReportWindow		Accounts:
+CapitalBe didn't understand the date you entered	ReportWindow		CapitalBe didn't understand the date you entered
+Cancel	Account		Cancel
 Options	PrefWindow		Options
 English	SplitView	Path to localized helpfiles. Only translate if available in your language.	English
 Edit category	BudgetWindow		Edit category
 Reconcile	ReconcileWindow		Reconcile
+CapitalBe uses the words 'Income', 'Spending', and 'Split' for managing categories, so you can't use them as category names. Please choose a different name for your new category.	CategoryWindow		CapitalBe uses the words 'Income', 'Spending', and 'Split' for managing categories, so you can't use them as category names. Please choose a different name for your new category.
 Weekly	ScheduleListWindow		Weekly
 Amount	SplitView		Amount
 Please choose a new category for all transactions currently in the '%%CATEGORY_NAME%%' category.	CategoryWindow		Please choose a new category for all transactions currently in the '%%CATEGORY_NAME%%' category.
 Reset	ReconcileWindow		Reset
 Frequency:	ScheduleAddWindow		Frequency:
-Category:	ScheduleAddWindow		Category:
-OK	AccountSettingsWindow		OK
+The split total must match the amount box	SplitView		The split total must match the amount box
 About CapitalBe	MainWindow		About CapitalBe
 No memo	ScheduledTransItem		No memo
-Annually	Budget		Annually
 Payee	SplitView		Payee
 Can't use this category name	CategoryWindow		Can't use this category name
+Do you want to add this transaction without a category?	CategoryWindow		Do you want to add this transaction without a category?
 Budget	BudgetWindow		Budget
 Monthly	BudgetWindow		Monthly
-CapitalBe didn't understand the amount for 'Interest earned'.	ReconcileWindow		CapitalBe didn't understand the amount for 'Interest earned'.
 OK	TransferWindow		OK
 Total worth	NetWorthReport		Total worth
 Memo	CheckView		Memo
@@ -158,90 +162,77 @@ Memo:	TransferWindow		Memo:
 Edit…	MainWindow		Edit…
 OK	CategoryWindow		OK
 Spending	ReportWindow		Spending
-Help	HelpButton		Help
 Total:	SplitView		Total:
 Unlimited	ScheduleListWindow		Unlimited
-Account settings	AccountSettingsWindow		Account settings
-Balance	QuickTrackerItem		Balance
 Set all to zero	BudgetWindow		Set all to zero
 When the split items are added together, they need to add up to %%ENTERED_AMOUNT%%. Currently, they add up to %%TOTAL_AMOUNT%%	SplitView		When the split items are added together, they need to add up to %%ENTERED_AMOUNT%%. Currently, they add up to %%TOTAL_AMOUNT%%
-Date is missing.	ReconcileWindow		Date is missing.
-Numbered transactions cannot be scheduled.	MainWindow		Numbered transactions cannot be scheduled.
 New…	MainWindow		New…
 English	ReconcileWindow	Path to localized helpfiles. Only translate if available in your language.	English
-Quick Balance failed. This doesn't mean that you did something wrong - it's just that Quick Balance works on simpler cases in balancing an account than this one. Sorry.	ReconcileWindow		Quick Balance failed. This doesn't mean that you did something wrong - it's just that Quick Balance works on simpler cases in balancing an account than this one. Sorry.
 Show split	SplitView		Show split
-Amount: %s	ScheduleAddWindow		Amount: %s
 Transfer	BudgetWindow		Transfer
-Amount:	BudgetWindow		Amount:
+Amount: %s	ScheduleAddWindow		Amount: %s
 Starting date:	ScheduleAddWindow		Starting date:
+Account settings	Account		Account settings
 Settings…	MainWindow		Settings…
-Monthly	Budget		Monthly
 Cancel	PrefWindow		Cancel
 Quarterly	ScheduleListWindow		Quarterly
 12 month statistics	BudgetWindow		12 month statistics
 Not transferring any money	TransferWindow		Not transferring any money
 Split	CategoryWindow		Split
+OK	Account		OK
 Income	ReportWindow		Income
 Memo	SplitView		Memo
-<No accounts>	QuickTrackerItem		<No accounts>
+Unknown	BudgetWindow		Unknown
+Numbered transactions cannot be scheduled	MainWindow		Numbered transactions cannot be scheduled
 Total checks:	ReconcileWindow		Total checks:
 Remove item	SplitView		Remove item
-Not enough accounts for a transfer.	MainWindow		Not enough accounts for a transfer.
 Amount	TransactionReport		Amount
 Transaction	MainWindow		Transaction
 Edit transfer	TransferWindow		Edit transfer
-Categories	CategoryWindow		Categories
+Amount	TransferWindow		Amount
 Reports	MainWindow		Reports
+Categories	CategoryWindow		Categories
 Date	CheckView		Date
-CapitalBe didn't understand the amount for 'Bank charges'.	ReconcileWindow		CapitalBe didn't understand the amount for 'Bank charges'.
 Account	MainWindow		Account
+Uncategorized	CategoryWindow		Uncategorized
 Currency format: %s	PrefWindow		Currency format: %s
 Payee	TransactionReport		Payee
 Total deposits:	ReconcileWindow		Total deposits:
 Categories…	MainWindow		Categories…
-CapitalBe didn't understand the amount.	CurrencyBox		CapitalBe didn't understand the amount.
 Day, Month, Year	PrefWindow		Day, Month, Year
 If you intend to transfer money, it will need to be an amount that is not zero.	TransferWindow		If you intend to transfer money, it will need to be an amount that is not zero.
 You can schedule transfers, deposits, or ATM transactions.	MainWindow		You can schedule transfers, deposits, or ATM transactions.
 Success!	ReconcileWindow		Success!
 Income	CategoryWindow		Income
 Edit category	CategoryWindow		Edit category
-Schedule transaction	ScheduleAddWindow		Schedule transaction
-Do you want to add this transaction without a category?	CategoryBox		Do you want to add this transaction without a category?
 This account is closed, and the settings cannot be edited. Please reopen the account if you need to make changes.	MainWindow		This account is closed, and the settings cannot be edited. Please reopen the account if you need to make changes.
 QuickTracker	RegisterView		QuickTracker
+Schedule transaction	ScheduleAddWindow		Schedule transaction
 Type: %s	ScheduleAddWindow		Type: %s
 New name:	CategoryWindow		New name:
-Weekly	Budget		Weekly
 Split	SplitFilterView		Split
 Bank charge	ReconcileWindow		Bank charge
 Budget	MainWindow		Budget
-Cancel	AccountSettingsWindow		Cancel
 Date	PrefWindow		Date
 OK	ScheduleAddWindow		OK
 Date	SplitView		Date
+Add	CategoryWindow		Add
 Quit	MainWindow		Quit
 Lowest	BudgetWindow		Lowest
 Previous	MainWindow		Previous
+Transaction type is missing	CheckView		Transaction type is missing
 Accounts	RegisterView		Accounts
-Payee is missing.	PayeeBox		Payee is missing.
 Type	CheckView		Type
-Account total:	QuickTrackerItem		Account total:
+Balance	MainWindow		Balance
 Export	MainWindow		Export
-You need to enter a check number or transaction type, such as ATM (for debit card transactions and the like), DEP (for deposits), or your own code for some other kind of expense.	CheckNumBox		You need to enter a check number or transaction type, such as ATM (for debit card transactions and the like), DEP (for deposits), or your own code for some other kind of expense.
 Enter a transfer…	MainWindow		Enter a transfer…
 File	MainWindow		File
 Tools	MainWindow		Tools
-Transaction type is missing.	CheckNumBox		Transaction type is missing.
-Uncategorized	CategoryBox		Uncategorized
-Split	TransactionItem		Split
+Not enough accounts for a transfer	MainWindow		Not enough accounts for a transfer
 Split	SplitView		Split
-The split total must match the amount box.	SplitView		The split total must match the amount box.
 Delete…	MainWindow		Delete…
 CapitalBe has run into a bug. This shouldn't happen, but it has.\nWould you like to:\n\n1) Save the bug to a text file for uploading to\nCapitalBe's issue tracker (https://github.com/HaikuArchives/CapitalBe/issues)\n\n2) Just quit and do nothing\n	Locale		CapitalBe has run into a bug. This shouldn't happen, but it has.\nWould you like to:\n\n1) Save the bug to a text file for uploading to\nCapitalBe's issue tracker (https://github.com/HaikuArchives/CapitalBe/issues)\n\n2) Just quit and do nothing\n
 Amount	BudgetWindow		Amount
-Cancel	CategoryBox		Cancel
 Scheduled transactions	ScheduleListWindow		Scheduled transactions
 Agh! Bug!	Locale		Agh! Bug!
 Starting date:	ReportWindow		Starting date:
@@ -249,6 +240,7 @@ Starting balance	ReconcileWindow		Starting balance
 Quarterly	ScheduleAddWindow		Quarterly
 Amount	CashFlowReport		Amount
 Reconcile:	ReconcileWindow		Reconcile:
+Use default currency settings	Account		Use default currency settings
 Total charges:	ReconcileWindow		Total charges:
 Total worth	ReportWindow		Total worth
 Expense	CashFlowReport		Expense
@@ -256,28 +248,25 @@ No transactions	TransactionReport		No transactions
 Date:	TransferWindow		Date:
 To account:	TransferWindow		To account:
 Add account transfer	TransferWindow		Add account transfer
+Quick balance failed. This doesn't mean that you did something wrong - it's just that 'Quick balance' works on simpler cases in balancing an account than this one. Sorry.	ReconcileWindow		Quick balance failed. This doesn't mean that you did something wrong - it's just that 'Quick balance' works on simpler cases in balancing an account than this one. Sorry.
 You need to have an account created in order to reconcile it.	MainWindow		You need to have an account created in order to reconcile it.
-Amount:	TransferWindow		Amount:
-CapitalBe understands lots of different ways of entering dates. Apparently, this wasn't one of them. You'll need to change how you entered this date. Sorry.	DateBox		CapitalBe understands lots of different ways of entering dates. Apparently, this wasn't one of them. You'll need to change how you entered this date. Sorry.
-There may be a typo or the wrong kind of currency symbol for this account.	CurrencyBox		There may be a typo or the wrong kind of currency symbol for this account.
+Payee is missing	TextInput		Payee is missing
 Next Payment	ScheduleListWindow		Next Payment
+CapitalBe didn't understand the date you entered	TextInput		CapitalBe didn't understand the date you entered
 Type	SplitView		Type
 Recalculate all	BudgetWindow		Recalculate all
 Date	NetWorthReport		Date
-CapitalBe didn't understand the date you entered.	ScheduleAddWindow		CapitalBe didn't understand the date you entered.
 Income	CashFlowReport		Income
 Hide split	SplitView		Hide split
 Split transaction	SplitView		Split transaction
-Could not export your financial data to the file '%%FILENAME%%'.	MainWindow		Could not export your financial data to the file '%%FILENAME%%'.
 Total checks: %s	ReconcileWindow		Total checks: %s
 English	ReportWindow	Path to localized helpfiles. Only translate if available in your language.	English
 Quarterly	BudgetWindow		Quarterly
 Remove category	CategoryWindow		Remove category
 You cannot schedule transactions on a closed account.	MainWindow		You cannot schedule transactions on a closed account.
 Decimal:	PrefWindow		Decimal:
-Split	ScheduleAddWindow		Split
+CapitalBe didn't understand the amount for 'Interest earned'	ReconcileWindow		CapitalBe didn't understand the amount for 'Interest earned'
 Month, Day, Year	PrefWindow		Month, Day, Year
-CapitalBe didn't understand the date you entered.	ReportWindow		CapitalBe didn't understand the date you entered.
-Use default currency settings	AccountSettingsWindow		Use default currency settings
+Split	ScheduleAddWindow		Split
+Date is missing	ReconcileWindow		Date is missing
 Unknown	ScheduleListWindow		Unknown
-No memo	TransactionItem		No memo

--- a/src/AccountListItem.cpp
+++ b/src/AccountListItem.cpp
@@ -11,7 +11,7 @@
 
 
 #undef B_TRANSLATION_CONTEXT
-#define B_TRANSLATION_CONTEXT "AccountListItem"
+#define B_TRANSLATION_CONTEXT "Account"
 
 
 AccountListItem::AccountListItem(Account* acc)

--- a/src/AccountSettingsWindow.cpp
+++ b/src/AccountSettingsWindow.cpp
@@ -10,7 +10,7 @@
 
 
 #undef B_TRANSLATION_CONTEXT
-#define B_TRANSLATION_CONTEXT "AccountSettingsWindow"
+#define B_TRANSLATION_CONTEXT "Account"
 
 
 #define M_EDIT_ACCOUNT_SETTINGS 'east'

--- a/src/Budget.cpp
+++ b/src/Budget.cpp
@@ -4,7 +4,7 @@
 
 
 #undef B_TRANSLATION_CONTEXT
-#define B_TRANSLATION_CONTEXT "Budget"
+#define B_TRANSLATION_CONTEXT "BudgetWindow"
 
 
 BudgetEntry::BudgetEntry(void)

--- a/src/BudgetReport.cpp
+++ b/src/BudgetReport.cpp
@@ -12,7 +12,7 @@
 
 
 #undef B_TRANSLATION_CONTEXT
-#define B_TRANSLATION_CONTEXT "BudgetReport"
+#define B_TRANSLATION_CONTEXT "BudgetWindow"
 
 
 /*

--- a/src/BudgetWindow.cpp
+++ b/src/BudgetWindow.cpp
@@ -713,7 +713,9 @@ BudgetWindow::BuildStatsAndEditor(void)
 
 	fMonthly->SetValue(B_CONTROL_ON);
 
-	fAmountLabel = new BStringView("amountlabel", B_TRANSLATE("Amount:"));
+	temp = B_TRANSLATE("Amount");
+	temp << ":";
+	fAmountLabel = new BStringView("amountlabel", temp.String());
 
 	fAmountBox = new CurrencyBox("amountbox", NULL, "$00,000.00", new BMessage(M_AMOUNT_CHANGED));
 }

--- a/src/CategoryBox.cpp
+++ b/src/CategoryBox.cpp
@@ -6,7 +6,7 @@
 #include "TimeSupport.h"
 
 #undef B_TRANSLATION_CONTEXT
-#define B_TRANSLATION_CONTEXT "CategoryBox"
+#define B_TRANSLATION_CONTEXT "CategoryWindow"
 
 
 CategoryBoxFilter::CategoryBoxFilter(CategoryBox* box)
@@ -79,7 +79,7 @@ bool
 CategoryBox::Validate(void)
 {
 	if (strlen(Text()) < 1) {
-		DAlert* alert = new DAlert(B_TRANSLATE("Category is missing."),
+		DAlert* alert = new DAlert(B_TRANSLATE("Category is missing"),
 			B_TRANSLATE("Do you want to add this transaction without a category?"),
 			B_TRANSLATE("Add"), B_TRANSLATE("Cancel"), NULL, B_WIDTH_AS_USUAL, B_WARNING_ALERT);
 		int32 value = alert->Go();

--- a/src/CheckNumBox.cpp
+++ b/src/CheckNumBox.cpp
@@ -8,7 +8,7 @@
 
 
 #undef B_TRANSLATION_CONTEXT
-#define B_TRANSLATION_CONTEXT "CheckNumBox"
+#define B_TRANSLATION_CONTEXT "CheckView"
 
 
 CheckNumBoxFilter::CheckNumBoxFilter(CheckNumBox* box)
@@ -120,7 +120,7 @@ bool
 CheckNumBox::Validate(void)
 {
 	if (strlen(Text()) < 1) {
-		ShowAlert(B_TRANSLATE("Transaction type is missing."),
+		ShowAlert(B_TRANSLATE("Transaction type is missing"),
 			B_TRANSLATE("You need to enter a check number or transaction type, such as "
 						"ATM (for debit card transactions and the like), DEP (for deposits), "
 						"or your own code for some other kind of expense."));

--- a/src/CurrencyBox.cpp
+++ b/src/CurrencyBox.cpp
@@ -8,7 +8,7 @@
 
 
 #undef B_TRANSLATION_CONTEXT
-#define B_TRANSLATION_CONTEXT "CurrencyBox"
+#define B_TRANSLATION_CONTEXT "TextInput"
 
 
 CurrencyBoxFilter::CurrencyBoxFilter(CurrencyBox* box)
@@ -68,7 +68,7 @@ CurrencyBox::Validate(bool alert)
 	Fixed amount;
 	if (gCurrentLocale.StringToCurrency(Text(), amount) != B_OK) {
 		if (alert) {
-			ShowAlert(B_TRANSLATE("CapitalBe didn't understand the amount."),
+			ShowAlert(B_TRANSLATE("CapitalBe didn't understand the amount"),
 				B_TRANSLATE("There may be a typo or the wrong kind of currency symbol "
 							"for this account."));
 			MakeFocus(true);

--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -185,7 +185,7 @@ Database::OpenFile(const char* path)
 		fDB.open(path);
 	} catch (...) {
 		UNLOCK;
-		ShowAlert("Couldn't open account data.",
+		ShowAlert("Couldn't open account data",
 			"CapitalBe couldn't open your financial data. "
 			"If your data is in the old storage format from the Preview Edition 1.0, you "
 			"will need to run the conversion program before you can use your data.");

--- a/src/DateBox.cpp
+++ b/src/DateBox.cpp
@@ -8,7 +8,7 @@
 
 
 #undef B_TRANSLATION_CONTEXT
-#define B_TRANSLATION_CONTEXT "DateBox"
+#define B_TRANSLATION_CONTEXT "TextInput"
 
 
 DateBoxFilter::DateBoxFilter(DateBox* box)
@@ -132,7 +132,7 @@ DateBox::Validate(const bool& alert)
 		SetText(date.String());
 	} else if (gDefaultLocale.StringToDate(Text(), tdate) != B_OK) {
 		if (alert) {
-			ShowAlert(B_TRANSLATE("CapitalBe didn't understand the date you entered."),
+			ShowAlert(B_TRANSLATE("CapitalBe didn't understand the date you entered"),
 				B_TRANSLATE("CapitalBe understands lots of different ways of entering dates. "
 							"Apparently, this wasn't one of them. You'll need to change how you "
 							"entered this date. Sorry."));

--- a/src/HelpButton.cpp
+++ b/src/HelpButton.cpp
@@ -9,7 +9,7 @@
 
 
 #undef B_TRANSLATION_CONTEXT
-#define B_TRANSLATION_CONTEXT "HelpButton"
+#define B_TRANSLATION_CONTEXT "MainWindow"
 
 
 class HelpButtonWindow : public BWindow {

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -172,15 +172,13 @@ MainWindow::MainWindow(BRect frame)
 
 	fImportPanel = new BFilePanel(B_OPEN_PANEL, new BMessenger(this), NULL, B_FILE_NODE, false,
 		new BMessage(M_IMPORT_ACCOUNT));
-	temp = B_TRANSLATE("CapitalBe:");
-	temp += " ";
-	temp += B_TRANSLATE("Import");
+	temp = B_TRANSLATE_SYSTEM_NAME("CapitalBe");
+	temp << ": " << B_TRANSLATE("Import");
 	fImportPanel->Window()->SetTitle(temp.String());
 	fExportPanel = new BFilePanel(B_SAVE_PANEL, new BMessenger(this), NULL, B_FILE_NODE, false,
 		new BMessage(M_EXPORT_ACCOUNT));
-	temp = B_TRANSLATE("CapitalBe:");
-	temp += " ";
-	temp += B_TRANSLATE("Export");
+	temp = B_TRANSLATE_SYSTEM_NAME("CapitalBe");
+	temp << ": " << B_TRANSLATE("Export");
 	fExportPanel->Window()->SetTitle(temp.String());
 	gDatabase.AddObserver(this);
 
@@ -346,7 +344,7 @@ MainWindow::MessageReceived(BMessage* msg)
 
 			if (!gDatabase.ImportFile(ref)) {
 				BString errmsg(
-					B_TRANSLATE("Could not import the data in the file '%%FILENAME%%'."));
+					B_TRANSLATE("Could not import the data in the file '%%FILENAME%%'"));
 				errmsg.ReplaceFirst("%%FILENAME%%", ref.name);
 				ShowAlert(errmsg.String(),
 					B_TRANSLATE("This happens when the kind of file is not "
@@ -376,7 +374,7 @@ MainWindow::MessageReceived(BMessage* msg)
 
 			if (!gDatabase.ExportFile(dir)) {
 				BString errmsg(B_TRANSLATE(
-					"Could not export your financial data to the file '%%FILENAME%%'."));
+					"Could not export your financial data to the file '%%FILENAME%%'"));
 				errmsg.ReplaceFirst("%%FILENAME%%", dir.name);
 				ShowAlert(
 					errmsg.String(), B_TRANSLATE("This really shouldn't happen, so you probably "
@@ -439,7 +437,7 @@ MainWindow::MessageReceived(BMessage* msg)
 		case M_ENTER_TRANSFER:
 		{
 			if (gDatabase.CountAccounts() < 2) {
-				ShowAlert(B_TRANSLATE("Not enough accounts for a transfer."),
+				ShowAlert(B_TRANSLATE("Not enough accounts for a transfer"),
 					B_TRANSLATE("You need to have at least 2 accounts to perform a transfer."));
 				break;
 			}
@@ -498,7 +496,7 @@ MainWindow::MessageReceived(BMessage* msg)
 			gDatabase.GetTransaction(acc->CurrentTransaction(), data);
 
 			if (data.Type().TypeCode() == TRANS_NUMERIC) {
-				ShowAlert(B_TRANSLATE("Numbered transactions cannot be scheduled."),
+				ShowAlert(B_TRANSLATE("Numbered transactions cannot be scheduled"),
 					B_TRANSLATE("You can schedule transfers, deposits, or ATM transactions."));
 				break;
 			}

--- a/src/PayeeBox.cpp
+++ b/src/PayeeBox.cpp
@@ -8,7 +8,7 @@
 
 
 #undef B_TRANSLATION_CONTEXT
-#define B_TRANSLATION_CONTEXT "PayeeBox"
+#define B_TRANSLATION_CONTEXT "TextInput"
 
 
 PayeeBoxFilter::PayeeBoxFilter(PayeeBox* box)
@@ -82,7 +82,7 @@ bool
 PayeeBox::Validate(const bool& showalert)
 {
 	if (showalert && (Text() == NULL || strlen(Text()) < 1)) {
-		ShowAlert(B_TRANSLATE("Payee is missing."), B_TRANSLATE("You need to enter a payee."));
+		ShowAlert(B_TRANSLATE("Payee is missing"), B_TRANSLATE("You need to enter a payee."));
 		MakeFocus(true);
 		return false;
 	}

--- a/src/QuickTrackerItem.cpp
+++ b/src/QuickTrackerItem.cpp
@@ -10,7 +10,7 @@
 
 
 #undef B_TRANSLATION_CONTEXT
-#define B_TRANSLATION_CONTEXT "QuickTrackerItem"
+#define B_TRANSLATION_CONTEXT "MainWindow"
 
 
 // Calculates the user's net worth by adding up the balances of all accounts
@@ -253,7 +253,7 @@ QTBudgetCategoryItem::HandleNotify(const uint64& value, const BMessage* msg)
 					Window()->Lock();
 
 				BString label, temp;
-				temp << B_TRANSLATE("Account total:") << " ";
+				temp << B_TRANSLATE("Account total") << ": ";
 				if (gCurrentLocale.CurrencyToString(Fixed(), label) == B_OK)
 					temp << label;
 				SetText(temp.String());
@@ -274,7 +274,7 @@ QTBudgetCategoryItem::Calculate(void)
 	BString label, temp;
 	Fixed variance;
 
-	temp << B_TRANSLATE("Budget:") << " " << fEntry.name;
+	temp << B_TRANSLATE("Budget") << ": " << fEntry.name;
 
 	if (gDefaultLocale.CurrencyToString(variance, label) == B_OK) {
 		temp << " \n" << label;

--- a/src/ReconcileWindow.cpp
+++ b/src/ReconcileWindow.cpp
@@ -591,7 +591,7 @@ ReconcileWindow::AutoReconcile(void)
 	if (gDefaultLocale.StringToDate(fDate->Text(), statdate) != B_OK) {
 		// Do we have an empty date box?
 		if (strlen(fDate->Text()) < 1) {
-			ShowAlert(B_TRANSLATE("Date is missing."),
+			ShowAlert(B_TRANSLATE("Date is missing"),
 				B_TRANSLATE("You need to enter the date for the statement to 'Quick balance'."));
 			return false;
 		}
@@ -604,7 +604,7 @@ ReconcileWindow::AutoReconcile(void)
 		if (gCurrentLocale.StringToCurrency(fCharges->Text(), bankchrg) == B_OK)
 			bankchrg.Invert();
 		else {
-			ShowAlert(B_TRANSLATE("CapitalBe didn't understand the amount for 'Bank charges'."),
+			ShowAlert(B_TRANSLATE("CapitalBe didn't understand the amount for 'Bank charges'"),
 				B_TRANSLATE("There may be a typo or the wrong kind of currency symbol "
 							"for this account."));
 			return false;
@@ -613,7 +613,7 @@ ReconcileWindow::AutoReconcile(void)
 
 	if (strlen(fInterest->Text()) > 0) {
 		if (gCurrentLocale.StringToCurrency(fInterest->Text(), interest) != B_OK) {
-			ShowAlert(B_TRANSLATE("CapitalBe didn't understand the amount for 'Interest earned'."),
+			ShowAlert(B_TRANSLATE("CapitalBe didn't understand the amount for 'Interest earned'"),
 				B_TRANSLATE("There may be a typo or the wrong kind of currency symbol "
 							"for this account."));
 			return false;
@@ -664,7 +664,7 @@ ReconcileWindow::AutoReconcile(void)
 		return true;
 	}
 
-	ShowAlert(B_TRANSLATE("Couldn't Quick balance."),
+	ShowAlert(B_TRANSLATE("Couldn't Quick balance"),
 		B_TRANSLATE("Quick balance failed. This doesn't mean "
 					"that you did something wrong - it's just that 'Quick balance' works on "
 					"simpler cases in balancing an account than this one. Sorry."));

--- a/src/ReportWindow.cpp
+++ b/src/ReportWindow.cpp
@@ -118,8 +118,8 @@ ReportWindow::ReportWindow(BRect frame)
 	//	account added when the report window is shown initially
 	//	fAccountList->SetSelectionMessage(new BMessage(M_TOGGLE_ACCOUNT));
 
-	temp = B_TRANSLATE("Subtotal:");
-	temp += " ";
+	temp = B_TRANSLATE("Subtotal");
+	temp += ": ";
 	sv = new BStringView("subtotalsv", temp.String());
 	subtotalLayout->AddView(sv);
 
@@ -345,7 +345,7 @@ ReportWindow::MessageReceived(BMessage* msg)
 					fStartDate = fEndDate;
 				RenderReport();
 			} else {
-				ShowAlert(B_TRANSLATE("CapitalBe didn't understand the date you entered."),
+				ShowAlert(B_TRANSLATE("CapitalBe didn't understand the date you entered"),
 					B_TRANSLATE(
 						"CapitalBe understands lots of different ways of entering dates. "
 						"Apparently, this wasn't one of them. You'll need to change how you "
@@ -369,7 +369,7 @@ ReportWindow::MessageReceived(BMessage* msg)
 					fStartDate = fEndDate;
 				RenderReport();
 			} else {
-				ShowAlert(B_TRANSLATE("CapitalBe didn't understand the date you entered."),
+				ShowAlert(B_TRANSLATE("CapitalBe didn't understand the date you entered"),
 					B_TRANSLATE(
 						"CapitalBe understands lots of different ways of entering dates. "
 						"Apparently, this wasn't one of them. You'll need to change how you "

--- a/src/ScheduleAddWindow.cpp
+++ b/src/ScheduleAddWindow.cpp
@@ -60,8 +60,8 @@ ScheduleAddWindow::ScheduleAddWindow(const BRect& frame, const TransactionData& 
 	label.SetToFormat(B_TRANSLATE("Amount: %s"), temp.String());
 	BStringView* amountlabel = new BStringView("amountlabel", label.String());
 
-	label = B_TRANSLATE("Category:");
-	label << " ";
+	label = B_TRANSLATE("Category");
+	label << ": ";
 	if (data.CountCategories() > 1)
 		label << B_TRANSLATE("Split");
 	else
@@ -69,8 +69,8 @@ ScheduleAddWindow::ScheduleAddWindow(const BRect& frame, const TransactionData& 
 
 	BStringView* categorylabel = new BStringView("categorylabel", label.String());
 
-	label = B_TRANSLATE("Memo:");
-	label << " " << data.Memo();
+	label = B_TRANSLATE("Memo");
+	label << ": " << data.Memo();
 	BStringView* memolabel = new BStringView("memolabel", label.String());
 
 	//	Since layout-api, we need other way to make divider
@@ -207,7 +207,7 @@ ScheduleAddWindow::MessageReceived(BMessage* msg)
 			BString datestr = fStartDate->Text();
 			if (datestr.CountChars() < 3 ||
 				gDefaultLocale.StringToDate(datestr.String(), tempdate) != B_OK) {
-				ShowAlert(B_TRANSLATE("CapitalBe didn't understand the date you entered."),
+				ShowAlert(B_TRANSLATE("CapitalBe didn't understand the date you entered"),
 					B_TRANSLATE(
 						"CapitalBe understands lots of different ways of entering dates. "
 						"Apparently, this wasn't one of them. You'll need to change how you "

--- a/src/SplitView.cpp
+++ b/src/SplitView.cpp
@@ -609,7 +609,7 @@ SplitView::ValidateSplitAmountField(void)
 
 	Fixed amount;
 	if (gCurrentLocale.StringToCurrency(fSplitAmount->Text(), amount) != B_OK) {
-		ShowAlert(B_TRANSLATE("CapitalBe didn't understand the amount."),
+		ShowAlert(B_TRANSLATE("CapitalBe didn't understand the amount"),
 			B_TRANSLATE("There may be a typo or the wrong kind of currency symbol "
 						"for this account."));
 		fSplitAmount->MakeFocus(true);
@@ -635,7 +635,7 @@ SplitView::ValidateSplitItems(void)
 	Fixed amount;
 	if (gCurrentLocale.StringToCurrency(fAmount->Text(), amount) != B_OK) {
 		fAmount->MakeFocus(true);
-		ShowAlert(B_TRANSLATE("CapitalBe didn't understand the amount."),
+		ShowAlert(B_TRANSLATE("CapitalBe didn't understand the amount"),
 			B_TRANSLATE("There may be a typo or the wrong kind of currency symbol "
 						"for this account."));
 		return false;
@@ -651,7 +651,7 @@ SplitView::ValidateSplitItems(void)
 		errormsg.ReplaceFirst("%%ENTERED_AMOUNT%%", fAmount->Text());
 		errormsg.ReplaceFirst("%%TOTAL_AMOUNT%%", totalstr.String());
 
-		ShowAlert(B_TRANSLATE("The split total must match the amount box."), errormsg.String());
+		ShowAlert(B_TRANSLATE("The split total must match the amount box"), errormsg.String());
 		fSplitAmount->MakeFocus(true);
 		return false;
 	}

--- a/src/TransactionEditWindow.cpp
+++ b/src/TransactionEditWindow.cpp
@@ -4,7 +4,7 @@
 
 
 #undef B_TRANSLATION_CONTEXT
-#define B_TRANSLATION_CONTEXT "TransactionEditWindow"
+#define B_TRANSLATION_CONTEXT "TransactionEdit"
 
 
 #define M_TOGGLE_SPLIT 'tspl'

--- a/src/TransactionItem.cpp
+++ b/src/TransactionItem.cpp
@@ -14,7 +14,7 @@
 
 
 #undef B_TRANSLATION_CONTEXT
-#define B_TRANSLATION_CONTEXT "TransactionItem"
+#define B_TRANSLATION_CONTEXT "TransactionEdit"
 
 
 TransactionItem::TransactionItem(const TransactionData& trans)

--- a/src/TransferWindow.cpp
+++ b/src/TransferWindow.cpp
@@ -69,8 +69,10 @@ TransferWindow::InitObject(Account* src, Account* dest, const Fixed& amount)
 	fMemo = new BTextControl("memobox", B_TRANSLATE("Memo:"), NULL, NULL);
 
 	BString amt;
+	BString temp = B_TRANSLATE("Amount");
+	temp << ":";
 	gCurrentLocale.CurrencyToString(amount, amt);
-	fAmount = new CurrencyBox("amountbox", B_TRANSLATE("Amount:"), amt.String(), NULL);
+	fAmount = new CurrencyBox("amountbox", temp.String(), amt.String(), NULL);
 	fAmount->GetFilter()->SetMessenger(new BMessenger(this));
 
 	fDate = new DateBox("datebox", B_TRANSLATE("Date:"), "", NULL);


### PR DESCRIPTION
- Clean up the language strings. I'm sure there are more that can be done, but this should reduce repeated terms a bit.
- Remove "." after dialog box titles.