### PR TITLE
Add database versioning

### DIFF
--- a/src/Account.cpp
+++ b/src/Account.cpp
@@ -68,8 +68,8 @@ Fixed
 Account::BalanceAt(const time_t& date)
 {
 	BString command;
-	command.SetToFormat("SELECT SUM(amount) FROM account_%i WHERE date <= %li ORDER BY payee;",
-		fID, date);
+	command.SetToFormat("SELECT SUM(amount) FROM account_%i WHERE date <= %li ORDER BY payee;", fID,
+		date);
 	CppSQLite3Query query = gDatabase.DBQuery(command.String(), "Account::BalanceAt");
 
 	int64 amount = 0;
@@ -90,7 +90,9 @@ Account::BalanceAtTransaction(const time_t& time, const char* payee)
 		return Fixed();
 
 	BString command;
-	command.SetToFormat("SELECT date,payee,amount FROM account_%i WHERE date <= %li ORDER BY date,payee;", fID, time);
+	command.SetToFormat(
+		"SELECT date,payee,amount FROM account_%i WHERE date <= %li ORDER BY date,payee;", fID,
+		time);
 	CppSQLite3Query query = gDatabase.DBQuery(command.String(), "Account::BalanceAt");
 
 	int64 amount = 0;
@@ -146,8 +148,7 @@ Account::AutocompletePayee(const char* input)
 	CppSQLite3Buffer bufSQL;
 	BString searchString;
 	searchString << input << "%";
-	bufSQL.format("SELECT payee FROM account_%i WHERE payee LIKE %Q", fID,
-		searchString.String());
+	bufSQL.format("SELECT payee FROM account_%i WHERE payee LIKE %Q", fID, searchString.String());
 	CppSQLite3Query query = gDatabase.DBQuery(bufSQL, "Account::AutocompletePayee");
 
 	if (query.eof())

--- a/src/Account.cpp
+++ b/src/Account.cpp
@@ -127,16 +127,16 @@ Account::AutocompleteCategory(const char* input)
 		if (strncasecmp(input, "Split", inputlength) == 0)
 			return "Split";
 	}
-
-	BString command;
-	command << ("SELECT name FROM categorylist WHERE name LIKE '") << EscapeIllegalCharacters(input)
-			<< "%' ;";
-	CppSQLite3Query query = gDatabase.DBQuery(command.String(), "Account::AutocompleteCategory");
+	CppSQLite3Buffer bufSQL;
+	BString searchString;
+	searchString << input << "%";
+	bufSQL.format("SELECT name FROM categorylist WHERE name LIKE %Q", searchString.String());
+	CppSQLite3Query query = gDatabase.DBQuery(bufSQL, "Account::AutocompleteCategory");
 
 	if (query.eof())
 		return NULL;
 
-	return DeescapeIllegalCharacters(query.getStringField(0));
+	return query.getStringField(0);
 }
 
 BString
@@ -145,16 +145,18 @@ Account::AutocompletePayee(const char* input)
 	if (!input)
 		return BString();
 
-	BString command;
-	command << ("SELECT payee FROM account_") << fID << " WHERE payee LIKE '"
-			<< EscapeIllegalCharacters(input) << "%' ;";
-
-	CppSQLite3Query query = gDatabase.DBQuery(command.String(), "Account::AutocompletePayee");
+	CppSQLite3Buffer bufSQL;
+	BString searchString, accountTable;
+	searchString << input << "%";
+	accountTable << "account_" << fID;
+	bufSQL.format("SELECT payee FROM %s WHERE payee LIKE %Q", accountTable.String(),
+		searchString.String());
+	CppSQLite3Query query = gDatabase.DBQuery(bufSQL, "Account::AutocompletePayee");
 
 	if (query.eof())
 		return NULL;
 
-	return DeescapeIllegalCharacters(query.getStringField(0));
+	return query.getStringField(0);
 }
 
 BString
@@ -179,16 +181,18 @@ Account::AutocompleteType(const char* input)
 			return str;
 	}
 
-	BString command;
-	command << ("SELECT type FROM account_") << fID << " WHERE type LIKE '"
-			<< EscapeIllegalCharacters(input) << "%' ;";
-
-	CppSQLite3Query query = gDatabase.DBQuery(command.String(), "Account::AutocompleteType");
+	CppSQLite3Buffer bufSQL;
+	BString searchString, accountTable;
+	searchString << input << "%";
+	accountTable << "account_" << fID;
+	bufSQL.format("SELECT type FROM %s WHERE type LIKE %Q", accountTable.String(),
+		searchString.String());
+	CppSQLite3Query query = gDatabase.DBQuery(bufSQL, "Account::AutocompleteType");
 
 	if (query.eof())
 		return BString();
 
-	return DeescapeIllegalCharacters(query.getStringField(0));
+	return query.getStringField(0);
 }
 
 Locale

--- a/src/BudgetWindow.cpp
+++ b/src/BudgetWindow.cpp
@@ -292,7 +292,7 @@ BudgetWindow::RefreshCategories(void)
 		"BudgetWindow::RefreshCategories");
 	float maxwidth = fCategoryList->StringWidth("Category");
 	while (!query.eof()) {
-		BString cat = DeescapeIllegalCharacters(query.getStringField(0));
+		BString cat = query.getStringField(0);
 		Fixed amount;
 		amount.SetPremultiplied(query.getInt64Field(1));
 		BudgetPeriod period = (BudgetPeriod)query.getIntField(2);
@@ -416,7 +416,7 @@ BudgetWindow::RefreshBudgetGrid(void)
 		= gDatabase.DBQuery("SELECT category,amount,period FROM budgetlist ORDER BY category",
 			"BudgetWindow::RefreshCategories");
 	while (!query.eof()) {
-		BString cat = DeescapeIllegalCharacters(query.getStringField(0));
+		BString cat = query.getStringField(0);
 		Fixed amount;
 		amount.SetPremultiplied(query.getInt64Field(1));
 		BudgetPeriod period = (BudgetPeriod)query.getIntField(2);
@@ -476,7 +476,7 @@ BudgetWindow::GenerateBudget(const bool& zero)
 
 	float maxwidth = fCategoryList->StringWidth(B_TRANSLATE_CONTEXT("Category", "CommonTerms"));
 	while (!query.eof()) {
-		BString catname = DeescapeIllegalCharacters(query.getStringField(0));
+		BString catname = query.getStringField(0);
 
 		if (catname.ICompare(B_TRANSLATE("Transfer")) == 0) {
 			query.nextRow();

--- a/src/CategoryWindow.cpp
+++ b/src/CategoryWindow.cpp
@@ -303,11 +303,9 @@ CategoryView::RefreshCategoryList(void)
 		BString name = query.getStringField(0);
 
 		if (expense == SPENDING)
-			fListView->AddUnder(
-				new CategoryItem(name.String()), fSpendingItem);
+			fListView->AddUnder(new CategoryItem(name.String()), fSpendingItem);
 		else if (expense == INCOME)
-			fListView->AddUnder(
-				new CategoryItem(name.String()), fIncomeItem);
+			fListView->AddUnder(new CategoryItem(name.String()), fIncomeItem);
 
 		if (name.CountChars() > maxchars) {
 			maxchars = name.CountChars();

--- a/src/CategoryWindow.cpp
+++ b/src/CategoryWindow.cpp
@@ -304,10 +304,10 @@ CategoryView::RefreshCategoryList(void)
 
 		if (expense == SPENDING)
 			fListView->AddUnder(
-				new CategoryItem(DeescapeIllegalCharacters(name.String())), fSpendingItem);
+				new CategoryItem(name.String()), fSpendingItem);
 		else if (expense == INCOME)
 			fListView->AddUnder(
-				new CategoryItem(DeescapeIllegalCharacters(name.String())), fIncomeItem);
+				new CategoryItem(name.String()), fIncomeItem);
 
 		if (name.CountChars() > maxchars) {
 			maxchars = name.CountChars();
@@ -491,7 +491,7 @@ CategoryRemoveWindow::CategoryRemoveWindow(const char* from, BView* target)
 
 	while (!query.eof()) {
 		int expense = query.getIntField(1);
-		BString name = DeescapeIllegalCharacters(query.getStringField(0));
+		BString name = query.getStringField(0);
 
 		if (name.Compare(from) == 0) {
 			query.nextRow();

--- a/src/CheckView.cpp
+++ b/src/CheckView.cpp
@@ -164,7 +164,7 @@ CheckView::MessageReceived(BMessage* msg)
 			msg->FindInt32("start", &start);
 			msg->FindString("string", &string);
 			fCategory->SetText(string.String());
-			fCategory->TextView()->Select(start, string.CountChars());
+			fCategory->TextView()->Select(start, string.CountChars() + 2);
 			break;
 		}
 

--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -189,8 +189,8 @@ Database::OpenFile(const char* path)
 
 	while (!query.eof()) {
 		uint32 id = query.getIntField(0);
-		BString name = DeescapeIllegalCharacters(query.getStringField(1));
-		BString status = DeescapeIllegalCharacters(query.getStringField(3));
+		BString name = query.getStringField(1);
+		BString status = query.getStringField(3);
 
 		Account* account = new Account(name.String(), status.ICompare("Open") != 0);
 		account->SetID(id);
@@ -626,15 +626,15 @@ Database::AddTransaction(const uint32& accountid, const uint32& id, const time_t
 	BString _memo = memo;
 
 	if (status == TRANS_CLEARED)
-		_status << "cleared');";
+		_status << "cleared";
 	else if (status == TRANS_RECONCILED)
-		_status << "reconciled');";
+		_status << "reconciled";
 	else
-		_status << "open');";
+		_status << "open";
 
 	_account << "account_" << accountid;
 
-	bufSQL.format("INSERT INTO %s VALUES(%i, %i, %li, %Q, %Q, %li, %Q, %Q, %Q)", _account.String(),
+	bufSQL.format("INSERT INTO %s VALUES(%i, %i, %li, %Q, %Q, %li, %Q, %Q, %Q);", _account.String(),
 		timestamp, id, date, type.Type(), payee, amount.AsFixed(), category, memo,
 		_status.String());
 
@@ -834,14 +834,14 @@ Database::GetTransaction(const uint32& transid, const uint32& accountid, Transac
 	data.MakeEmpty();
 	data.SetAccount(AccountByID(accountid));
 	data.SetDate(atol(query.getStringField(0)));
-	data.SetPayee(DeescapeIllegalCharacters(query.getStringField(1)).String());
-	data.SetType(DeescapeIllegalCharacters(query.getStringField(5)).String());
+	data.SetPayee(query.getStringField(1));
+	data.SetType(query.getStringField(5));
 	data.SetID(transid);
 	while (!query.eof()) {
 		Fixed f;
 		f.SetPremultiplied(atol(query.getStringField(2)));
 
-		data.AddCategory(DeescapeIllegalCharacters(query.getStringField(3)).String(), f, true);
+		data.AddCategory(query.getStringField(3), f, true);
 
 		if (!query.fieldIsNull(4))
 			data.SetMemoAt(data.CountCategories() - 1, query.getStringField(4));
@@ -850,7 +850,7 @@ Database::GetTransaction(const uint32& transid, const uint32& accountid, Transac
 	}
 
 	if ((data.CountCategories() == 1) && strlen(data.MemoAt(0)) > 0)
-		data.SetMemo(DeescapeIllegalCharacters(data.MemoAt(0)));
+		data.SetMemo(data.MemoAt(0));
 
 	UNLOCK;
 	return true;
@@ -1047,8 +1047,8 @@ Database::GetScheduledTransaction(const uint32& transid, ScheduledTransData& dat
 
 	data.SetID(transid);
 	data.SetDate(query.getInt64Field(1));
-	data.SetPayee(DeescapeIllegalCharacters(query.getStringField(2)).String());
-	data.SetType(DeescapeIllegalCharacters(query.getStringField(6)).String());
+	data.SetPayee(query.getStringField(2));
+	data.SetType(query.getStringField(6));
 	data.SetNextDueDate(query.getInt64Field(7));
 	data.SetCount(query.getIntField(8));
 	data.SetInterval((TransactionInterval)query.getIntField(9));
@@ -1056,17 +1056,16 @@ Database::GetScheduledTransaction(const uint32& transid, ScheduledTransData& dat
 		Fixed f;
 		f.SetPremultiplied(atol(query.getStringField(3)));
 
-		data.AddCategory(DeescapeIllegalCharacters(query.getStringField(4)).String(), f, true);
+		data.AddCategory(query.getStringField(4), f, true);
 
 		if (!query.fieldIsNull(4))
-			data.SetMemoAt(
-				data.CountCategories() - 1, DeescapeIllegalCharacters(query.getStringField(5)));
+			data.SetMemoAt(data.CountCategories() - 1, query.getStringField(5));
 
 		query.nextRow();
 	}
 
 	if ((data.CountCategories() == 1) && strlen(data.MemoAt(0)) > 0)
-		data.SetMemo(DeescapeIllegalCharacters(data.MemoAt(0)));
+		data.SetMemo(data.MemoAt(0));
 
 	UNLOCK;
 	return true;

--- a/src/Database.h
+++ b/src/Database.h
@@ -108,13 +108,16 @@ public:
 	CppSQLite3Query DBQuery(const char* query, const char* functionname);
 
 private:
+	status_t ApplyMigrations(void);
+	status_t CreateDBBackup(int32 version);
+	status_t DeescapeDatabase(void);
 	int32 GetLastKey(const char* table, const char* column);
 
 	// Used to allow split scheduled transactions
 	bool InsertSchedTransaction(const uint32& id, const uint32& accountid, const time_t& startdate,
 		const TransactionType& type, const char* payee, const Fixed& amount, const char* category,
 		const char* memo, const TransactionInterval& interval, const time_t& nextdate,
-		const int32& count = -1);
+		const int32& count = -1, const int32& destination = -1);
 
 	Account* fCurrent;
 	BObjectList<Account> fList;

--- a/src/Import.cpp
+++ b/src/Import.cpp
@@ -410,14 +410,14 @@ ExportQIF(const entry_ref& ref)
 			temp.RemoveFirst(gDefaultLocale.CurrencySymbol());
 			text << "U" << temp << "\nT" << temp << "\n";
 
-			text << "N" << DeescapeIllegalCharacters(query.getStringField(3)) << "\n";
-			text << "P" << DeescapeIllegalCharacters(query.getStringField(4)) << "\n";
+			text << "N" << query.getStringField(3) << "\n";
+			text << "P" << query.getStringField(4) << "\n";
 
-			temp = DeescapeIllegalCharacters(query.getStringField(7));
+			temp = query.getStringField(7);
 			if (temp.CountChars() > 0)
 				text << "M" << temp << "\n";
 
-			text << "L" << DeescapeIllegalCharacters(query.getStringField(6)) << "\n^\n";
+			text << "L" << query.getStringField(6) << "\n^\n";
 			query.nextRow();
 		}
 
@@ -467,8 +467,9 @@ MakeCategoryString(const DStringList& list, const bool& isexpense)
 
 	for (int32 i = 0; i < list.CountItems(); i++) {
 		BString* category = list.ItemAt(i);
-		BString unescaped(DeescapeIllegalCharacters(category->String()));
-		text << "N" << unescaped << "\nD" << unescaped << "\n" << (isexpense ? "E" : "I") << "\n";
+		BString unescaped(category->String());
+		text << "N" << unescaped.String() << "\nD" << unescaped.String() << "\n"
+			 << (isexpense ? "E" : "I") << "\n";
 
 		// See if the category is in the budget and, if so, write it to disk if nonzero
 		BudgetEntry entry;

--- a/src/PrefWindow.cpp
+++ b/src/PrefWindow.cpp
@@ -84,7 +84,7 @@ CurrencyPrefView::CurrencyPrefView(const char* name, Locale* locale, const int32
 
 	fCurrencySymbolBox = new AutoTextControl("moneysym", B_TRANSLATE("Symbol:"),
 		fLocale.CurrencySymbol(), new BMessage(M_NEW_CURRENCY_SYMBOL));
-	fCurrencySymbolBox->SetCharacterLimit(2);
+	fCurrencySymbolBox->SetCharacterLimit(4);
 
 	fCurrencySymbolPrefix = new BCheckBox(
 		"prefixcheck", B_TRANSLATE("Appears before amount"), new BMessage(M_NEW_CURRENCY_SYMBOL));

--- a/src/QuickTrackerItem.cpp
+++ b/src/QuickTrackerItem.cpp
@@ -157,7 +157,7 @@ QTNetWorthItem::Calculate(void)
 		Locale accLocale;
 
 		while (!query.eof()) {
-			Account* account = gDatabase.AccountAt(query.getIntField(0));
+			Account* account = gDatabase.AccountByID(query.getIntField(0));
 			balance += account->Balance();
 			accLocale = account->GetLocale();
 			query.nextRow();

--- a/src/ReportWindow.cpp
+++ b/src/ReportWindow.cpp
@@ -464,7 +464,7 @@ ReportWindow::AddAccount(Account* acc)
 	CppSQLite3Query query = gDatabase.DBQuery(command.String(), "ReportWindow::AddAccount");
 
 	while (!query.eof()) {
-		BString catstr = DeescapeIllegalCharacters(query.getStringField(0));
+		BString catstr = query.getStringField(0);
 		if (catstr.CountChars() < 1) {
 			query.nextRow();
 			continue;

--- a/src/ReportWindow.cpp
+++ b/src/ReportWindow.cpp
@@ -539,13 +539,14 @@ ReportWindow::CalcCategoryString(void)
 {
 	// Compile list of selected categories
 	fCategoryString = "";
+	CppSQLite3Buffer bufSQL;
 	for (int32 i = 0; i < fCategoryList->CountItems(); i++) {
 		BStringItem* catitem = (BStringItem*)fCategoryList->ItemAt(i);
 		if (catitem && catitem->IsSelected()) {
 			if (fCategoryString.CountChars() > 0)
-				fCategoryString << ",'" << EscapeIllegalCharacters(catitem->Text()) << "'";
+				fCategoryString << bufSQL.format(",%Q", catitem->Text());
 			else
-				fCategoryString << "'" << EscapeIllegalCharacters(catitem->Text()) << "'";
+				fCategoryString << bufSQL.format("%Q", catitem->Text());
 		}
 	}
 }

--- a/src/ScheduleListWindow.cpp
+++ b/src/ScheduleListWindow.cpp
@@ -258,7 +258,7 @@ ScheduleListView::RefreshScheduleList(void)
 		row->SetField(new BStringField(string.String()), 4);
 
 		// memo
-		row->SetField(new BStringField(DeescapeIllegalCharacters(sdata->Memo())), 5);
+		row->SetField(new BStringField(sdata->Memo()), 5);
 	}
 
 	fListView->ColumnAt(0)->SetWidth(maxwidth + 30);

--- a/src/SplitView.cpp
+++ b/src/SplitView.cpp
@@ -159,7 +159,7 @@ SplitView::SplitView(const char* name, const TransactionData& trans, const int32
 		SplitItem* item = new SplitItem();
 		item->SetCategory(fTransaction.NameAt(i));
 		item->SetAmount(fTransaction.AmountAt(i));
-		item->SetMemo(DeescapeIllegalCharacters(fTransaction.MemoAt(i)));
+		item->SetMemo(fTransaction.MemoAt(i));
 
 		fSplitItems->AddItem(item);
 	}
@@ -515,7 +515,7 @@ SplitView::MessageReceived(BMessage* msg)
 			gCurrentLocale.CurrencyToString(item->GetAmount().AbsoluteValue(), amount);
 			fSplitAmount->SetText(amount.String());
 
-			fSplitMemo->SetText(DeescapeIllegalCharacters(item->GetMemo()));
+			fSplitMemo->SetText(item->GetMemo());
 			fSplitCategory->TextView()->SelectAll();
 			break;
 		}

--- a/src/TransactionReport.cpp
+++ b/src/TransactionReport.cpp
@@ -156,12 +156,10 @@ ReportWindow::ComputeTransactions(void)
 				row->SetField(new BStringField(tempstr.String()), 1);
 
 				// type
-				row->SetField(
-					new BStringField(DeescapeIllegalCharacters(query.getStringField(1)).String()),
-					2);
+				row->SetField(new BStringField(query.getStringField(1)), 2);
 
 				// payee
-				tempstr = DeescapeIllegalCharacters(query.getStringField(2));
+				tempstr = query.getStringField(2);
 				if (tempstr.CountChars() > payeechars) {
 					payeechars = tempstr.CountChars();
 					maxpayee = fGridView->StringWidth(tempstr.String());
@@ -174,7 +172,7 @@ ReportWindow::ComputeTransactions(void)
 				row->SetField(new BStringField(tempstr.String()), 4);
 
 				// category
-				tempstr = DeescapeIllegalCharacters(query.getStringField(4));
+				tempstr = query.getStringField(4);
 				if (tempstr.CountChars() > categorychars) {
 					categorychars = tempstr.CountChars();
 					maxcategory = fGridView->StringWidth(tempstr.String());
@@ -183,7 +181,7 @@ ReportWindow::ComputeTransactions(void)
 
 				// memo
 				if (!query.fieldIsNull(5)) {
-					tempstr = DeescapeIllegalCharacters(query.getStringField(5));
+					tempstr = query.getStringField(5);
 					if (tempstr.CountChars() > memochars) {
 						memochars = tempstr.CountChars();
 						maxmemo = fGridView->StringWidth(tempstr.String());

--- a/src/TransactionView.cpp
+++ b/src/TransactionView.cpp
@@ -83,17 +83,16 @@ TransactionView::SetAccount(Account* acc)
 		newid = query.getIntField(1);
 		data.SetID(currentid);
 		data.SetDate(atol(query.getStringField(2)));
-		data.SetType(DeescapeIllegalCharacters(query.getStringField(3)).String());
-		data.SetPayee(DeescapeIllegalCharacters(query.getStringField(4)).String());
+		data.SetType(query.getStringField(3));
+		data.SetPayee(query.getStringField(4));
 		data.SetAccount(acc);
 
 		Fixed f;
 		f.SetPremultiplied(atol(query.getStringField(5)));
-		data.AddCategory(DeescapeIllegalCharacters(query.getStringField(6)).String(), f, true);
+		data.AddCategory(query.getStringField(6), f, true);
 
 		if (!query.fieldIsNull(7))
-			data.SetMemoAt(data.CountCategories() - 1,
-				DeescapeIllegalCharacters(query.getStringField(7)).String());
+			data.SetMemoAt(data.CountCategories() - 1, query.getStringField(7));
 
 		BString status = query.getStringField(8);
 		if (status.ICompare("Reconciled") == 0)
@@ -119,17 +118,16 @@ TransactionView::SetAccount(Account* acc)
 				newid = query.getIntField(1);
 				data.SetID(currentid);
 				data.SetDate(atol(query.getStringField(2)));
-				data.SetType(DeescapeIllegalCharacters(query.getStringField(3)).String());
-				data.SetPayee(DeescapeIllegalCharacters(query.getStringField(4)).String());
+				data.SetType(query.getStringField(3));
+				data.SetPayee(query.getStringField(4));
 				data.SetAccount(acc);
 			}
 
 			f.SetPremultiplied(atol(query.getStringField(5)));
-			data.AddCategory(DeescapeIllegalCharacters(query.getStringField(6)).String(), f, true);
+			data.AddCategory(query.getStringField(6), f, true);
 
 			if (!query.fieldIsNull(7))
-				data.SetMemoAt(data.CountCategories() - 1,
-					DeescapeIllegalCharacters(query.getStringField(7)).String());
+				data.SetMemoAt(data.CountCategories() - 1, query.getStringField(7));
 
 			status = query.getStringField(8);
 			if (status.ICompare("Reconciled") == 0)


### PR DESCRIPTION
This is an attempt to prepare for possible future DB changes (e.g. when using system locale for dates and currencies) without the need for a conversion tool. Users upgrading from previous versions (or even before versioning was implemented) will automatically have any DB changes applied.

I'm not sure if my logic is correct or if there is a better way to implement this, any feedback appreciated. It seems to work with databases from CapitalBe 1.1.0 from HaikuDepot. Maybe an automatic backup of the current database would be a good idea in order to protect user data.

Each time a release requires database changes, the version number in `Database.cpp` is incremented, and the required logic (changing tables and migrating data) must be added as a new if-clause in `Database::ApplyMigrations()`. This function handles each version incrementally.