### PR TITLE
Fix the coloring for different system themes

### DIFF
--- a/src/AccountListItem.cpp
+++ b/src/AccountListItem.cpp
@@ -43,8 +43,13 @@ AccountListItem::DrawItem(BView* owner, BRect frame, bool complete)
 
 	// Draw account title
 	owner->SetFont(be_bold_font);
-	owner->SetHighUIColor(
-		B_LIST_ITEM_TEXT_COLOR, fAccount->IsClosed() ? GetMutedTint(CB_MUTED_TEXT) : B_NO_TINT);
+	if (IsSelected()) {
+		owner->SetHighUIColor(B_LIST_SELECTED_ITEM_TEXT_COLOR, fAccount->IsClosed()
+			? GetMutedTint(ui_color(B_LIST_SELECTED_BACKGROUND_COLOR), CB_MUTED_TEXT) : B_NO_TINT);
+	} else {
+		owner->SetHighUIColor(B_LIST_ITEM_TEXT_COLOR, fAccount->IsClosed()
+			? GetMutedTint(ui_color(B_LIST_BACKGROUND_COLOR), CB_MUTED_TEXT) : B_NO_TINT);
+	}
 
 	BFont font;
 	owner->DrawString(fAccount->Name(), BPoint(frame.left + 5, frame.top + (font.Size())));

--- a/src/Preferences.cpp
+++ b/src/Preferences.cpp
@@ -63,12 +63,12 @@ LoadPreferences(const char* path)
 
 
 bool
-IsDark()
+IsDark(rgb_color color)
 {
-	rgb_color color = ui_color(B_PANEL_BACKGROUND_COLOR);
 	// From http://alienryderflex.com/hsp.html
 	// Useful in particular to decide if the color is "light" or "dark"
 	// by checking if the perceptual brightness is > 127.
+	// TODO: Once Haiku Beta5 is out, we can use its IsDark()
 
 	int32 brightness =
 		(uint8)roundf(sqrtf(0.299f * color.red * color.red + 0.587f * color.green * color.green +
@@ -79,16 +79,16 @@ IsDark()
 
 
 const float
-GetMutedTint(const CapitalBeMuted& type)
+GetMutedTint(const rgb_color color, const CapitalBeMuted& type)
 {
 	switch (type) {
 		case CB_MUTED_TEXT:
 		{
-			return IsDark() ? B_DARKEN_2_TINT : B_LIGHTEN_1_TINT;
+			return IsDark(color) ? B_DARKEN_2_TINT : B_LIGHTEN_1_TINT;
 		}
 		case CB_MUTED_BG:
 		{
-			return IsDark() ? B_LIGHTEN_2_TINT : B_DARKEN_1_TINT;
+			return IsDark(color) ? B_LIGHTEN_2_TINT : B_DARKEN_1_TINT;
 		}
 		default:
 			return B_NO_TINT;

--- a/src/Preferences.h
+++ b/src/Preferences.h
@@ -29,6 +29,6 @@ typedef enum {
 } CapitalBeMuted;
 
 rgb_color GetColor(const CapitalBeColor& color);
-const float GetMutedTint(const CapitalBeMuted& type);
+const float GetMutedTint(const rgb_color color, const CapitalBeMuted& type);
 
 #endif

--- a/src/ScheduledTransItem.cpp
+++ b/src/ScheduledTransItem.cpp
@@ -176,7 +176,8 @@ ScheduledTransItem::DrawItem(BView* owner, BRect frame, bool complete)
 		owner->SetHighUIColor(B_LIST_ITEM_TEXT_COLOR);
 		owner->DrawString(fMemo.String(), BPoint(xpos + 5, ypos - 3));
 	} else {
-		owner->SetHighUIColor(B_LIST_ITEM_TEXT_COLOR, GetMutedTint(CB_MUTED_TEXT));
+		owner->SetHighUIColor(B_LIST_ITEM_TEXT_COLOR,
+			GetMutedTint(ui_color(B_LIST_ITEM_TEXT_COLOR), CB_MUTED_TEXT));
 		owner->DrawString(B_TRANSLATE("No memo"), BPoint(xpos + 5, ypos - 3));
 	}
 	owner->ConstrainClippingRegion(NULL);


### PR DESCRIPTION
* Use B_LIST_SELECTED_ITEM_TEXT_COLOR when drawing text of a selected item.

* When calling GetMutedTint() to draw items of a closed account, it's not OK to check always against B_PANEL_BACKGROUND_COLOR to determine if to lighten or darken. We need to compare to the background colour the text will be drawn on or - vice-versa - the text colour that will be drawn on the background colour.

  Therefore, we call GetMutedTint() with the colour we want it have compared to.

* Added TODO to use Haiku's IsDark() once Haiku Beta 5 is out.

* Replace SetHighUIColor() with SetHighColor(), because the former can only deal with the system color_which constants, not rgb_color.

* Fixed "No memo" not being drawn tinted in closed accounts.