### PR TITLE
Setting: configurable negative amount colour

### DIFF
--- a/locales/en.catkeys
+++ b/locales/en.catkeys
@@ -1,4 +1,4 @@
-1	English	application/x-vnd.wgp-CapitalBe	248763939
+1	English	application/x-vnd.wgp-CapitalBe	3882412825
 Year	ReportWindow		Year
 None	ReportWindow		None
 Export to QIF file…	MainWindow		Export to QIF file…
@@ -22,9 +22,11 @@ Account total	MainWindow		Account total
 CapitalBe	System name		CapitalBe
 Total: %sum%	SplitView		Total: %sum%
 Import from QIF file…	MainWindow		Import from QIF file…
+Preview:	PrefWindow		Preview:
 Ending date:	ReportWindow		Ending date:
 Scheduled transactions	MainWindow		Scheduled transactions
 Separator:	PrefWindow		Separator:
+Closed account:	PrefWindow		Closed account:
 Help: Report	ReportWindow		Help: Report
 Bank charges	ReconcileWindow		Bank charges
 Transfer to '%%PAYEE%%'	MainWindow		Transfer to '%%PAYEE%%'
@@ -69,9 +71,11 @@ Quit	Locale		Quit
 Once deleted, you will not be able to get back any data on this account.	MainWindow		Once deleted, you will not be able to get back any data on this account.
 Add category	CategoryWindow		Add category
 Could not export your financial data to the file '%%FILENAME%%'	MainWindow		Could not export your financial data to the file '%%FILENAME%%'
+Currency format:	PrefWindow		Currency format:
 Name:	Account		Name:
 Total deposits: %s	ReconcileWindow		Total deposits: %s
 Memo	CommonTerms		Memo
+Selected:	PrefWindow		Selected:
 Save bugreport	Locale		Save bugreport
 Type	CommonTerms		Type
 Indefinitely	ScheduleAddWindow		Indefinitely
@@ -142,6 +146,7 @@ Show split	SplitView		Show split
 Transfer	BudgetWindow		Transfer
 Starting date:	ScheduleAddWindow		Starting date:
 Account settings	Account		Account settings
+Color for negative amounts	PrefWindow		Color for negative amounts
 Settings…	MainWindow		Settings…
 Cancel	PrefWindow		Cancel
 Budget category:	BudgetWindow		Budget category:
@@ -160,7 +165,7 @@ Reports	MainWindow		Reports
 Categories	CategoryWindow		Categories
 Account	MainWindow		Account
 Uncategorized	CategoryWindow		Uncategorized
-Currency format: %s	PrefWindow		Currency format: %s
+Unselected:	PrefWindow		Unselected:
 Total deposits:	ReconcileWindow		Total deposits:
 Categories…	MainWindow		Categories…
 Help: Budget	BudgetWindow		Help: Budget

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -498,7 +498,7 @@ MainWindow::MessageReceived(BMessage* msg)
 		}
 		case M_SHOW_OPTIONS_WINDOW:
 		{
-			PrefWindow* pwin = new PrefWindow(Frame());
+			PrefWindow* pwin = new PrefWindow(Frame(), this);
 			pwin->Show();
 			break;
 		}
@@ -547,6 +547,16 @@ MainWindow::MessageReceived(BMessage* msg)
 			CategoryWindow* catwin = new CategoryWindow(BRect(100, 100, 600, 425));
 			catwin->CenterIn(Frame());
 			catwin->Show();
+			break;
+		}
+		case M_NEG_COLOR_CHANGED:
+		{
+			BView* view = fRegisterView->FindView("transactionview");
+			if (view != NULL) {
+				view = view->FindView("RegisterList");
+				if (view != NULL)
+					view->Invalidate();
+			}
 			break;
 		}
 		default:

--- a/src/PrefWindow.h
+++ b/src/PrefWindow.h
@@ -4,6 +4,7 @@
 #include <Box.h>
 #include <Button.h>
 #include <CheckBox.h>
+#include <ColorControl.h>
 #include <MenuField.h>
 #include <Message.h>
 #include <RadioButton.h>
@@ -18,21 +19,51 @@
 
 class DatePrefView;
 class CurrencyPrefView;
+class NegativeNumberView;
+
+
+// PrefWindow
+enum {
+	M_EDIT_OPTIONS = 'edop',
+	M_NEG_COLOR_CHANGED
+};
+
+// CurrencyPrefView
+enum {
+	M_NEW_CURRENCY_SYMBOL,
+	M_NEW_CURRENCY_SEPARATOR,
+	M_NEW_CURRENCY_DECIMAL,
+	M_TOGGLE_PREFIX,
+	M_CURRENCY_UPADTED
+};
+
+// NegativeNumberView
+enum {
+	M_UPDATE_COLOR
+};
+
 
 class PrefWindow : public BWindow {
 public:
-	PrefWindow(const BRect& frame);
+	PrefWindow(const BRect& frame, BMessenger target);
+
+	void AllAttached();
 	void MessageReceived(BMessage* msg);
 
 private:
+	void InitSettings(void);
+
+	BMessenger fTarget;
+	rgb_color fNegativeColor;
 	CurrencyPrefView* fCurrencyPrefView;
-	BButton* fOK;
-	BStringView* fLabel;
+	NegativeNumberView* fNegNumberView;
 };
+
 
 class CurrencyPrefView : public BView {
 public:
 	CurrencyPrefView(const char* name, Locale* locale = NULL, const int32& flags = B_WILL_DRAW);
+
 	void AttachedToWindow(void);
 	void MessageReceived(BMessage* msg);
 
@@ -44,9 +75,27 @@ private:
 	BBox* fCurrencyBox;
 	AutoTextControl *fCurrencySymbolBox, *fCurrencyDecimalBox, *fCurrencySeparatorBox;
 	BCheckBox* fCurrencySymbolPrefix;
-
+	BStringView* fCurrencyPreview;
 	Locale fLocale;
 	Fixed fSampleAmount;
+};
+
+
+class NegativeNumberView : public BView {
+public:
+	NegativeNumberView(const char* name, rgb_color negColor);
+
+	void AttachedToWindow(void);
+	void MessageReceived(BMessage* msg);
+
+	void GetColor(rgb_color& color);
+
+private:
+	void UpdateText(BString text);
+	void UpdateColor(rgb_color color);
+
+	BColorControl* fNegativeColor;
+	BTextView *fSelectedPreview, *fUnselectedPreview, *fClosedPreview;
 };
 
 #endif

--- a/src/Preferences.cpp
+++ b/src/Preferences.cpp
@@ -9,10 +9,6 @@
 BLocker prefsLock;
 BMessage gPreferences;
 
-static rgb_color sSelectionFocusColor = {205, 205, 255, 255};
-static rgb_color sSelectionNoFocusColor = {205, 205, 230, 255};
-static rgb_color sGridHeaderColor = {225, 225, 255, 255};
-
 
 status_t
 SavePreferences(const char* path)
@@ -93,31 +89,4 @@ GetMutedTint(const rgb_color color, const CapitalBeMuted& type)
 		default:
 			return B_NO_TINT;
 	}
-}
-
-
-rgb_color
-GetColor(const CapitalBeColor& color)
-{
-	rgb_color returncolor = {0, 0, 0, 0};
-
-	switch (color) {
-		case BC_SELECTION_NOFOCUS:
-		{
-			returncolor = sSelectionNoFocusColor;
-			break;
-		}
-		case BC_SELECTION_FOCUS:
-		{
-			returncolor = sSelectionFocusColor;
-			break;
-		}
-		case BC_GRID_HEADER:
-		{
-			returncolor = sGridHeaderColor;
-		}
-		default:
-			break;
-	}
-	return returncolor;
 }

--- a/src/Preferences.h
+++ b/src/Preferences.h
@@ -17,18 +17,10 @@ status_t SavePreferences(const char* path);
 status_t LoadPreferences(const char* path);
 
 typedef enum {
-	BC_SELECTION_FOCUS = 0,
-	BC_SELECTION_NOFOCUS,
-	BC_GRID_HEADER
-
-} CapitalBeColor;
-
-typedef enum {
 	CB_MUTED_TEXT = 0,
 	CB_MUTED_BG
 } CapitalBeMuted;
 
-rgb_color GetColor(const CapitalBeColor& color);
 const float GetMutedTint(const rgb_color color, const CapitalBeMuted& type);
 
 #endif

--- a/src/TransactionItem.cpp
+++ b/src/TransactionItem.cpp
@@ -124,8 +124,15 @@ TransactionItem::DrawItem(BView* owner, BRect frame, bool complete)
 
 	owner->SetHighColor(tint_color(textColor, textTint));
 	Fixed balance = fAccount->BalanceAtTransaction(fDate, fPayee.String());
-	if (balance.AsFixed() < 0)
-		owner->SetHighUIColor(B_FAILURE_COLOR, textTint);
+	if (balance.AsFixed() < 0) {
+		rgb_color negativeColor;
+		if (gPreferences.FindColor("negativecolor", &negativeColor) != B_OK)
+			negativeColor = ui_color(B_FAILURE_COLOR);
+		if (IsSelected())
+			owner->SetHighColor(negativeColor);
+		else
+			owner->SetHighColor(tint_color(negativeColor, textTint));
+	}
 	locale.CurrencyToString(balance, string);
 	owner->DrawString(string.String(), BPoint(xpos + 5, ypos - 6));
 


### PR DESCRIPTION
Because the B_FAILURE_COLOR can clash with custom system colour settings.

* Some layout changes for the currency format settings to accommodate the added colour settings.

* Added a NegativeNumberView that shows
  + a BColorControl to pick a colour for negative amounts
  + a preview of a negative amount of that colour on 3 different backgrounds: selected and unselected list item, and of a closed account.

* Adjust the preview when the currency format gets changed.

* Save/Load the "negativecolor" with the gPreferences.

* Inform the MainWindow of the negative amount colour with a BMessage when the settings are confirmed via OK button.

* Have the MainWindow find the view of the "RegisterList" and force it to redraw.

* Remove unused GetColor() and its constants from Preferences.

* Updated en.catkeys