### PR TITLE
Currency locale

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,9 @@ SRCS = \
 	 src/HelpButton.cpp  \
 	 src/Import.cpp  \
 	 src/IconMenuItem.cpp \
+	 src/LanguageListView \
 	 src/Locale.cpp  \
+	 src/LocaleView.cpp \
 	 src/MainWindow.cpp  \
 	 src/NavTextBox.cpp  \
 	 src/NetWorthReport.cpp  \

--- a/src/Account.cpp
+++ b/src/Account.cpp
@@ -197,6 +197,7 @@ Account::GetLocale(void) const
 	return fUseDefaultLocale ? gDefaultLocale : fLocale;
 }
 
+
 void
 Account::SetLocale(const Locale& locale)
 {
@@ -322,15 +323,13 @@ Account::UseDefaultLocale(const bool& usedefault)
 
 	BString command;
 	if (fUseDefaultLocale) {
-		command = "delete from accountlocale where accountid = ";
+		command = "DELETE FROM accountlocale WHERE accountid = ";
 		command << fID << ";";
 		gDatabase.DBCommand(command.String(), "Account::UseDefaultLocale");
 		gCurrentLocale = gDefaultLocale;
 	} else {
 		// update the local copy in case it changed since the program was opened
-		fLocale = gDefaultLocale;
-
-		gDatabase.SetAccountLocale(fID, fLocale);
+		fLocale = gCurrentLocale;
 	}
 
 	BMessage msg;

--- a/src/Account.h
+++ b/src/Account.h
@@ -68,6 +68,7 @@ private:
 	uint32 fCurrentTransaction;
 	uint32 fLastCheckNumber;
 	Locale fLocale;
+	BString fAccountLocale;
 	bool fUseDefaultLocale;
 };
 

--- a/src/AccountSettingsWindow.cpp
+++ b/src/AccountSettingsWindow.cpp
@@ -87,21 +87,22 @@ AccountSettingsWindow::MessageReceived(BMessage* msg)
 	switch (msg->what) {
 		case M_EDIT_ACCOUNT_SETTINGS:
 		{
-			Locale customLocale;
-			Locale defaultLocale;
+			Locale locale;
+			BString customSystemLocale; // from select list
+			fLocaleView->GetCurrentLocale(customSystemLocale);
 
 			if (!fAccount) {
-				fPrefView->GetSettings(customLocale);
-				gDatabase.AddAccount(fAccountName->Text(), ACCOUNT_BANK, "Open",
-					defaultLocale == customLocale ? NULL : &customLocale);
+				if (fUseDefault->Value() == B_CONTROL_ON);
+					locale.SetAccountLocale(customSystemLocale);
+				gDatabase.AddAccount(fAccountName->Text(), ACCOUNT_BANK, "Open", &locale);
 			} else {
 				if (strcmp(fAccountName->Text(), fAccount->Name()) != 0)
 					gDatabase.RenameAccount(fAccount, fAccountName->Text());
 
-				fPrefView->GetSettings(customLocale);
 				if (fUseDefault->Value() != B_CONTROL_ON) {
 					fAccount->UseDefaultLocale(false);
-					fAccount->SetLocale(customLocale);
+					locale.SetAccountLocale(customSystemLocale);
+					fAccount->SetLocale(locale);
 				} else {
 					fAccount->UseDefaultLocale(true);
 				}

--- a/src/AccountSettingsWindow.cpp
+++ b/src/AccountSettingsWindow.cpp
@@ -44,6 +44,7 @@ AccountSettingsWindow::AccountSettingsWindow(Account* account)
 	if (fAccount)
 		templocale = fAccount->GetLocale();
 	fPrefView = new CurrencyPrefView("prefview", &templocale);
+	fLocaleView = new LocaleView("localeview");
 
 	fOK = new BButton("okbutton", B_TRANSLATE("OK"), new BMessage(M_EDIT_ACCOUNT_SETTINGS));
 
@@ -57,6 +58,7 @@ AccountSettingsWindow::AccountSettingsWindow(Account* account)
 
 	if (!fAccount || fAccount->IsUsingDefaultLocale()) {
 		fPrefView->Hide();
+		fLocaleView->Hide();
 	}
 	// clang-format off
 	BLayoutBuilder::Group<>(this, B_VERTICAL, B_USE_DEFAULT_SPACING)
@@ -64,7 +66,7 @@ AccountSettingsWindow::AccountSettingsWindow(Account* account)
 		.AddGroup(B_VERTICAL, B_USE_DEFAULT_SPACING)
 			.Add(fAccountName)
 			.Add(fUseDefault)
-			.Add(fPrefView)
+			.Add(fLocaleView)
 			.End()
 		.AddGroup(B_HORIZONTAL, B_USE_DEFAULT_SPACING)
 			.AddGlue()
@@ -113,9 +115,9 @@ AccountSettingsWindow::MessageReceived(BMessage* msg)
 			bool useDefault = fUseDefault->Value() == B_CONTROL_ON;
 
 			if (useDefault)
-				fPrefView->Hide();
+				fLocaleView->Hide();
 			else
-				fPrefView->Show();
+				fLocaleView->Show();
 
 			break;
 		}

--- a/src/AccountSettingsWindow.cpp
+++ b/src/AccountSettingsWindow.cpp
@@ -43,7 +43,6 @@ AccountSettingsWindow::AccountSettingsWindow(Account* account)
 	Locale templocale;
 	if (fAccount)
 		templocale = fAccount->GetLocale();
-	fPrefView = new CurrencyPrefView("prefview", &templocale);
 	fLocaleView = new LocaleView("localeview");
 
 	fOK = new BButton("okbutton", B_TRANSLATE("OK"), new BMessage(M_EDIT_ACCOUNT_SETTINGS));
@@ -57,7 +56,6 @@ AccountSettingsWindow::AccountSettingsWindow(Account* account)
 	SetDefaultButton(fOK);
 
 	if (!fAccount || fAccount->IsUsingDefaultLocale()) {
-		fPrefView->Hide();
 		fLocaleView->Hide();
 	}
 	// clang-format off
@@ -92,8 +90,9 @@ AccountSettingsWindow::MessageReceived(BMessage* msg)
 			fLocaleView->GetCurrentLocale(customSystemLocale);
 
 			if (!fAccount) {
-				if (fUseDefault->Value() == B_CONTROL_ON);
-					locale.SetAccountLocale(customSystemLocale);
+				if (fUseDefault->Value() == B_CONTROL_ON)
+					;
+				locale.SetAccountLocale(customSystemLocale);
 				gDatabase.AddAccount(fAccountName->Text(), ACCOUNT_BANK, "Open", &locale);
 			} else {
 				if (strcmp(fAccountName->Text(), fAccount->Name()) != 0)

--- a/src/AccountSettingsWindow.h
+++ b/src/AccountSettingsWindow.h
@@ -1,12 +1,12 @@
 #ifndef NEW_ACCOUNT_WINDOW_H
 #define NEW_ACCOUNT_WINDOW_H
 
+#include "Fixed.h"
+#include "LocaleView.h"
 #include <Button.h>
 #include <CheckBox.h>
 #include <View.h>
 #include <Window.h>
-#include "Fixed.h"
-#include "LocaleView.h"
 
 class AutoTextControl;
 class CurrencyPrefView;

--- a/src/AccountSettingsWindow.h
+++ b/src/AccountSettingsWindow.h
@@ -6,6 +6,7 @@
 #include <View.h>
 #include <Window.h>
 #include "Fixed.h"
+#include "LocaleView.h"
 
 class AutoTextControl;
 class CurrencyPrefView;
@@ -22,6 +23,7 @@ private:
 	AutoTextControl* fAccountName;
 	BButton* fOK;
 	CurrencyPrefView* fPrefView;
+	LocaleView* fLocaleView;
 	Account* fAccount;
 	BCheckBox* fUseDefault;
 };

--- a/src/BudgetReport.cpp
+++ b/src/BudgetReport.cpp
@@ -139,7 +139,7 @@ ReportWindow::ComputeBudget(void)
 	// Later this will iterate over all items in the category list
 	BStringItem* stringitem = (BStringItem*)fCategoryList->ItemAt(0);
 	if (!stringitem) {
-		//ShowBug("NULL category BStringItem in ReportWindow::ComputeBudget");
+		// ShowBug("NULL category BStringItem in ReportWindow::ComputeBudget");
 		return;
 	}
 

--- a/src/BudgetReport.cpp
+++ b/src/BudgetReport.cpp
@@ -139,7 +139,7 @@ ReportWindow::ComputeBudget(void)
 	// Later this will iterate over all items in the category list
 	BStringItem* stringitem = (BStringItem*)fCategoryList->ItemAt(0);
 	if (!stringitem) {
-		ShowBug("NULL category BStringItem in ReportWindow::ComputeBudget");
+		//ShowBug("NULL category BStringItem in ReportWindow::ComputeBudget");
 		return;
 	}
 

--- a/src/CBLocale.h
+++ b/src/CBLocale.h
@@ -30,6 +30,9 @@ public:
 	status_t StringToDate(const char* instring, time_t& date);
 	void NumberToCurrency(const Fixed& number, BString& string);
 
+	void SetAccountLocale(const char* languageID);
+	const char* AccountLocale(void) const { return fAccountLocale.String(); }
+
 	void SetCurrencySymbol(const char* symbol);
 
 	const char* CurrencySymbol(void) const { return fCurrencySymbol.String(); }
@@ -62,6 +65,7 @@ private:
 	status_t ConstructDateStringDMY(const char* in, BString& out);
 
 	BString fCurrencySymbol;
+	BString fAccountLocale;
 	bool fPrefixSymbol;
 	BString fCurrencySeparator;
 	BString fCurrencyDecimal;

--- a/src/CBLocale.h
+++ b/src/CBLocale.h
@@ -8,11 +8,6 @@
 #include "DAlert.h"
 #include "Fixed.h"
 
-typedef enum {
-	DATE_MDY = 1,
-	DATE_DMY = 2
-} date_format;
-
 class Locale {
 public:
 	Locale(void);
@@ -26,51 +21,24 @@ public:
 	status_t CurrencyToString(const Fixed& amount, BString& string);
 	status_t DateToString(time_t date, BString& string);
 	status_t StringToCurrency(const char* string, Fixed& amount);
-	status_t PremultipliedStringToCurrency(const char* string, Fixed& amount);
 	status_t StringToDate(const char* instring, time_t& date);
-	void NumberToCurrency(const Fixed& number, BString& string);
 
 	void SetAccountLocale(const char* languageID);
 	const char* AccountLocale(void) const { return fAccountLocale.String(); }
 
-	void SetCurrencySymbol(const char* symbol);
-
 	const char* CurrencySymbol(void) const { return fCurrencySymbol.String(); }
-
-	void SetCurrencySeparator(const char* symbol);
-
 	const char* CurrencySeparator(void) const { return fCurrencySeparator.String(); }
-
-	void SetCurrencyDecimal(const char* symbol);
-
 	const char* CurrencyDecimal(void) const { return fCurrencyDecimal.String(); }
-
-	void SetCurrencySymbolPrefix(const bool& value);
-
-	bool IsCurrencySymbolPrefix(void) const { return fPrefixSymbol; }
-
-	void SetCurrencyDecimalPlace(const uint8& place);
-
-	uint8 CurrencyDecimalPlace(void) const { return fCurrencyDecimalPlace; }
-
-	void SetDST(const bool& value);
-
-	bool UseDST(void) const { return fUseDST; }
 
 private:
 	friend class CapitalBeParser;
 
 	void SetDefaults(void);
-	status_t ConstructDateStringMDY(const char* in, BString& out);
-	status_t ConstructDateStringDMY(const char* in, BString& out);
 
-	BString fCurrencySymbol;
 	BString fAccountLocale;
-	bool fPrefixSymbol;
+	BString fCurrencySymbol;
 	BString fCurrencySeparator;
 	BString fCurrencyDecimal;
-	uint8 fCurrencyDecimalPlace;
-	bool fUseDST;
 };
 
 void ShowAlert(const char* header, const char* message, alert_type type = B_INFO_ALERT);

--- a/src/Database.h
+++ b/src/Database.h
@@ -69,8 +69,6 @@ public:
 
 	void SetAccountLocale(const uint32& accountid, const Locale& data);
 	Locale LocaleForAccount(const uint32& id);
-	void SetDefaultLocale(const Locale& data);
-	Locale GetDefaultLocale(void);
 	bool UsesDefaultLocale(const uint32& id);
 
 	bool AddTransaction(const uint32& accountid, const uint32& id, const time_t& date,

--- a/src/LanguageListView.cpp
+++ b/src/LanguageListView.cpp
@@ -1,0 +1,511 @@
+/*
+ * Copyright 2006-2010, Haiku Inc. All rights reserved.
+ * Distributed under the terms of the MIT License.
+ *
+ * Authors:
+ *		Stephan Aßmus <superstippi@gmx.de>
+ *		Adrien Destugues <pulkomandy@gmail.com>
+ *		Axel Dörfler, axeld@pinc-software.de
+ *		Oliver Tappe <zooey@hirschkaefer.de>
+ */
+
+
+#include "LanguageListView.h"
+
+#include <stdio.h>
+
+#include <new>
+
+#include <Bitmap.h>
+#include <Catalog.h>
+#include <ControlLook.h>
+#include <FormattingConventions.h>
+#include <GradientLinear.h>
+#include <LocaleRoster.h>
+#include <Region.h>
+#include <Window.h>
+
+
+#define MAX_DRAG_HEIGHT		200.0
+#define ALPHA				170
+
+#undef B_TRANSLATION_CONTEXT
+#define B_TRANSLATION_CONTEXT "LanguageListView"
+
+
+LanguageListItem::LanguageListItem(const char* text, const char* id,
+	const char* languageCode)
+	:
+	BStringItem(text),
+	fID(id),
+	fCode(languageCode)
+{
+}
+
+
+LanguageListItem::LanguageListItem(const LanguageListItem& other)
+	:
+	BStringItem(other.Text()),
+	fID(other.fID),
+	fCode(other.fCode)
+{
+}
+
+
+void
+LanguageListItem::DrawItem(BView* owner, BRect frame, bool complete)
+{
+	DrawItemWithTextOffset(owner, frame, complete, 0);
+}
+
+
+void
+LanguageListItem::DrawItemWithTextOffset(BView* owner, BRect frame,
+	bool complete, float textOffset)
+{
+	rgb_color highColor = owner->HighColor();
+	rgb_color lowColor = owner->LowColor();
+
+	if (IsSelected() || complete) {
+		rgb_color color;
+		if (IsSelected())
+			color = ui_color(B_LIST_SELECTED_BACKGROUND_COLOR);
+		else
+			color = owner->ViewColor();
+
+		owner->SetHighColor(color);
+		owner->SetLowColor(color);
+		owner->FillRect(frame);
+	} else
+		owner->SetLowColor(owner->ViewColor());
+
+	BString text = Text();
+	if (!IsEnabled()) {
+		rgb_color textColor = ui_color(B_LIST_ITEM_TEXT_COLOR);
+		if (textColor.red + textColor.green + textColor.blue > 128 * 3)
+			owner->SetHighColor(tint_color(textColor, B_DARKEN_2_TINT));
+		else
+			owner->SetHighColor(tint_color(textColor, B_LIGHTEN_2_TINT));
+
+		text << "   [" << B_TRANSLATE("already chosen") << "]";
+	} else {
+		if (IsSelected())
+			owner->SetHighColor(ui_color(B_LIST_SELECTED_ITEM_TEXT_COLOR));
+		else
+			owner->SetHighColor(ui_color(B_LIST_ITEM_TEXT_COLOR));
+	}
+
+	owner->MovePenTo(
+		frame.left + be_control_look->DefaultLabelSpacing() + textOffset,
+		frame.top + BaselineOffset());
+	owner->DrawString(text.String());
+
+	owner->SetHighColor(highColor);
+	owner->SetLowColor(lowColor);
+}
+
+
+// #pragma mark -
+
+
+LanguageListItemWithFlag::LanguageListItemWithFlag(const char* text,
+	const char* id, const char* languageCode, const char* countryCode)
+	:
+	LanguageListItem(text, id, languageCode),
+	fCountryCode(countryCode),
+	fIcon(NULL)
+{
+}
+
+
+LanguageListItemWithFlag::LanguageListItemWithFlag(
+	const LanguageListItemWithFlag& other)
+	:
+	LanguageListItem(other),
+	fCountryCode(other.fCountryCode),
+	fIcon(other.fIcon != NULL ? new BBitmap(*other.fIcon) : NULL)
+{
+}
+
+
+LanguageListItemWithFlag::~LanguageListItemWithFlag()
+{
+	delete fIcon;
+}
+
+
+void
+LanguageListItemWithFlag::Update(BView* owner, const BFont* font)
+{
+	LanguageListItem::Update(owner, font);
+
+	float iconSize = Height();
+	SetWidth(Width() + iconSize + be_control_look->DefaultLabelSpacing());
+
+	if (fCountryCode.IsEmpty())
+		return;
+
+	fIcon = new(std::nothrow) BBitmap(BRect(0, 0, iconSize - 1, iconSize - 1),
+		B_RGBA32);
+	if (fIcon != NULL && BLocaleRoster::Default()->GetFlagIconForCountry(fIcon,
+			fCountryCode.String()) != B_OK) {
+		delete fIcon;
+		fIcon = NULL;
+	}
+}
+
+
+void
+LanguageListItemWithFlag::DrawItem(BView* owner, BRect frame, bool complete)
+{
+	if (fIcon == NULL || !fIcon->IsValid()) {
+		DrawItemWithTextOffset(owner, frame, complete, 0);
+		return;
+	}
+
+	float iconSize = fIcon->Bounds().Width();
+	DrawItemWithTextOffset(owner, frame, complete,
+		iconSize + be_control_look->DefaultLabelSpacing());
+
+	BRect iconFrame(frame.left + be_control_look->DefaultLabelSpacing(),
+		frame.top,
+		frame.left + iconSize - 1 + be_control_look->DefaultLabelSpacing(),
+		frame.top + iconSize - 1);
+	owner->SetDrawingMode(B_OP_OVER);
+	owner->DrawBitmap(fIcon, iconFrame);
+	owner->SetDrawingMode(B_OP_COPY);
+}
+
+
+// #pragma mark -
+
+
+LanguageListView::LanguageListView(const char* name, list_view_type type)
+	:
+	BOutlineListView(name, type),
+	fDropIndex(-1),
+	fDropTargetHighlightFrame(),
+	fGlobalDropTargetIndicator(false),
+	fDeleteMessage(NULL),
+	fDragMessage(NULL)
+{
+}
+
+
+LanguageListView::~LanguageListView()
+{
+}
+
+
+LanguageListItem*
+LanguageListView::ItemForLanguageID(const char* id, int32* _index) const
+{
+	for (int32 index = 0; index < FullListCountItems(); index++) {
+		LanguageListItem* item
+			= static_cast<LanguageListItem*>(FullListItemAt(index));
+
+		if (item->ID() == id) {
+			if (_index != NULL)
+				*_index = index;
+			return item;
+		}
+	}
+
+	return NULL;
+}
+
+
+LanguageListItem*
+LanguageListView::ItemForLanguageCode(const char* code, int32* _index) const
+{
+	for (int32 index = 0; index < FullListCountItems(); index++) {
+		LanguageListItem* item
+			= static_cast<LanguageListItem*>(FullListItemAt(index));
+
+		if (item->Code() == code) {
+			if (_index != NULL)
+				*_index = index;
+			return item;
+		}
+	}
+
+	return NULL;
+}
+
+
+void
+LanguageListView::SetDeleteMessage(BMessage* message)
+{
+	delete fDeleteMessage;
+	fDeleteMessage = message;
+}
+
+
+void
+LanguageListView::SetDragMessage(BMessage* message)
+{
+	delete fDragMessage;
+	fDragMessage = message;
+}
+
+
+void
+LanguageListView::SetGlobalDropTargetIndicator(bool isGlobal)
+{
+	fGlobalDropTargetIndicator = isGlobal;
+}
+
+
+void
+LanguageListView::AttachedToWindow()
+{
+	BOutlineListView::AttachedToWindow();
+	ScrollToSelection();
+}
+
+
+void
+LanguageListView::MessageReceived(BMessage* message)
+{
+	if (message->WasDropped() && _AcceptsDragMessage(message)) {
+		// Someone just dropped something on us
+		BMessage dragMessage(*message);
+		dragMessage.AddInt32("drop_index", fDropIndex);
+		dragMessage.AddPointer("drop_target", this);
+		Messenger().SendMessage(&dragMessage);
+	} else
+		BOutlineListView::MessageReceived(message);
+}
+
+
+void
+LanguageListView::Draw(BRect updateRect)
+{
+	BOutlineListView::Draw(updateRect);
+
+	if (fDropIndex >= 0 && fDropTargetHighlightFrame.IsValid()) {
+		// TODO: decide if drawing of a drop target indicator should be moved
+		//       into ControlLook
+		BGradientLinear gradient;
+		int step = fGlobalDropTargetIndicator ? 64 : 128;
+		for (int i = 0; i < 256; i += step)
+			gradient.AddColor(i % (step * 2) == 0
+				? ViewColor() : ui_color(B_CONTROL_HIGHLIGHT_COLOR), i);
+		gradient.AddColor(ViewColor(), 255);
+		gradient.SetStart(fDropTargetHighlightFrame.LeftTop());
+		gradient.SetEnd(fDropTargetHighlightFrame.RightBottom());
+		if (fGlobalDropTargetIndicator) {
+			BRegion region(fDropTargetHighlightFrame);
+			region.Exclude(fDropTargetHighlightFrame.InsetByCopy(2.0, 2.0));
+			ConstrainClippingRegion(&region);
+			FillRect(fDropTargetHighlightFrame, gradient);
+			ConstrainClippingRegion(NULL);
+		} else
+			FillRect(fDropTargetHighlightFrame, gradient);
+	}
+}
+
+
+bool
+LanguageListView::InitiateDrag(BPoint point, int32 dragIndex,
+	bool /*wasSelected*/)
+{
+	if (fDragMessage == NULL)
+		return false;
+
+	BListItem* item = ItemAt(CurrentSelection(0));
+	if (item == NULL) {
+		// workaround for a timing problem
+		// TODO: this should support extending the selection
+		item = ItemAt(dragIndex);
+		Select(dragIndex);
+	}
+	if (item == NULL)
+		return false;
+
+	// create drag message
+	BMessage message = *fDragMessage;
+	message.AddPointer("listview", this);
+
+	for (int32 i = 0;; i++) {
+		int32 index = CurrentSelection(i);
+		if (index < 0)
+			break;
+
+		message.AddInt32("index", index);
+	}
+
+	// figure out drag rect
+
+	BRect dragRect(0.0, 0.0, Bounds().Width(), -1.0);
+	int32 numItems = 0;
+	bool fade = false;
+
+	// figure out, how many items fit into our bitmap
+	for (int32 i = 0, index; message.FindInt32("index", i, &index) == B_OK;
+			i++) {
+		BListItem* item = ItemAt(index);
+		if (item == NULL)
+			break;
+
+		dragRect.bottom += ceilf(item->Height()) + 1.0;
+		numItems++;
+
+		if (dragRect.Height() > MAX_DRAG_HEIGHT) {
+			dragRect.bottom = MAX_DRAG_HEIGHT;
+			fade = true;
+			break;
+		}
+	}
+
+	BBitmap* dragBitmap = new BBitmap(dragRect, B_RGB32, true);
+	if (dragBitmap->IsValid()) {
+		BView* view = new BView(dragBitmap->Bounds(), "helper", B_FOLLOW_NONE,
+			B_WILL_DRAW);
+		dragBitmap->AddChild(view);
+		dragBitmap->Lock();
+		BRect itemBounds(dragRect) ;
+		itemBounds.bottom = 0.0;
+		// let all selected items, that fit into our drag_bitmap, draw
+		for (int32 i = 0; i < numItems; i++) {
+			int32 index = message.FindInt32("index", i);
+			LanguageListItem* item
+				= static_cast<LanguageListItem*>(ItemAt(index));
+			itemBounds.bottom = itemBounds.top + ceilf(item->Height());
+			if (itemBounds.bottom > dragRect.bottom)
+				itemBounds.bottom = dragRect.bottom;
+			item->DrawItem(view, itemBounds);
+			itemBounds.top = itemBounds.bottom + 1.0;
+		}
+		// make a black frame around the edge
+		view->SetHighColor(0, 0, 0, 255);
+		view->StrokeRect(view->Bounds());
+		view->Sync();
+
+		uint8* bits = (uint8*)dragBitmap->Bits();
+		int32 height = (int32)dragBitmap->Bounds().Height() + 1;
+		int32 width = (int32)dragBitmap->Bounds().Width() + 1;
+		int32 bpr = dragBitmap->BytesPerRow();
+
+		if (fade) {
+			for (int32 y = 0; y < height - ALPHA / 2; y++, bits += bpr) {
+				uint8* line = bits + 3;
+				for (uint8* end = line + 4 * width; line < end; line += 4)
+					*line = ALPHA;
+			}
+			for (int32 y = height - ALPHA / 2; y < height;
+				y++, bits += bpr) {
+				uint8* line = bits + 3;
+				for (uint8* end = line + 4 * width; line < end; line += 4)
+					*line = (height - y) << 1;
+			}
+		} else {
+			for (int32 y = 0; y < height; y++, bits += bpr) {
+				uint8* line = bits + 3;
+				for (uint8* end = line + 4 * width; line < end; line += 4)
+					*line = ALPHA;
+			}
+		}
+		dragBitmap->Unlock();
+	} else {
+		delete dragBitmap;
+		dragBitmap = NULL;
+	}
+
+	if (dragBitmap != NULL)
+		DragMessage(&message, dragBitmap, B_OP_ALPHA, BPoint(0.0, 0.0));
+	else
+		DragMessage(&message, dragRect.OffsetToCopy(point), this);
+
+	return true;
+}
+
+
+void
+LanguageListView::MouseMoved(BPoint where, uint32 transit,
+	const BMessage* dragMessage)
+{
+	if (dragMessage != NULL && _AcceptsDragMessage(dragMessage)) {
+		switch (transit) {
+			case B_ENTERED_VIEW:
+			case B_INSIDE_VIEW:
+			{
+				BRect highlightFrame;
+
+				if (fGlobalDropTargetIndicator) {
+					highlightFrame = Bounds();
+					fDropIndex = 0;
+				} else {
+					// offset where by half of item height
+					BRect r = ItemFrame(0);
+					where.y += r.Height() / 2.0;
+
+					int32 index = IndexOf(where);
+					if (index < 0)
+						index = CountItems();
+					highlightFrame = ItemFrame(index);
+					if (highlightFrame.IsValid())
+						highlightFrame.bottom = highlightFrame.top;
+					else {
+						highlightFrame = ItemFrame(index - 1);
+						if (highlightFrame.IsValid())
+							highlightFrame.top = highlightFrame.bottom;
+						else {
+							// empty view, show indicator at top
+							highlightFrame = Bounds();
+							highlightFrame.bottom = highlightFrame.top;
+						}
+					}
+					fDropIndex = index;
+				}
+
+				if (fDropTargetHighlightFrame != highlightFrame) {
+					Invalidate(fDropTargetHighlightFrame);
+					fDropTargetHighlightFrame = highlightFrame;
+					Invalidate(fDropTargetHighlightFrame);
+				}
+
+				BOutlineListView::MouseMoved(where, transit, dragMessage);
+				return;
+			}
+		}
+	}
+
+	if (fDropTargetHighlightFrame.IsValid()) {
+		Invalidate(fDropTargetHighlightFrame);
+		fDropTargetHighlightFrame = BRect();
+	}
+	BOutlineListView::MouseMoved(where, transit, dragMessage);
+}
+
+
+void
+LanguageListView::MouseUp(BPoint point)
+{
+	BOutlineListView::MouseUp(point);
+	if (fDropTargetHighlightFrame.IsValid()) {
+		Invalidate(fDropTargetHighlightFrame);
+		fDropTargetHighlightFrame = BRect();
+	}
+}
+
+
+void
+LanguageListView::KeyDown(const char* bytes, int32 numBytes)
+{
+	if (bytes[0] == B_DELETE && fDeleteMessage != NULL) {
+		Invoke(fDeleteMessage);
+		return;
+	}
+
+	BOutlineListView::KeyDown(bytes, numBytes);
+}
+
+
+bool
+LanguageListView::_AcceptsDragMessage(const BMessage* message) const
+{
+	LanguageListView* sourceView = NULL;
+	return message != NULL
+		&& message->FindPointer("listview", (void**)&sourceView) == B_OK;
+}

--- a/src/LanguageListView.cpp
+++ b/src/LanguageListView.cpp
@@ -26,15 +26,14 @@
 #include <Window.h>
 
 
-#define MAX_DRAG_HEIGHT		200.0
-#define ALPHA				170
+#define MAX_DRAG_HEIGHT 200.0
+#define ALPHA 170
 
 #undef B_TRANSLATION_CONTEXT
 #define B_TRANSLATION_CONTEXT "LanguageListView"
 
 
-LanguageListItem::LanguageListItem(const char* text, const char* id,
-	const char* languageCode)
+LanguageListItem::LanguageListItem(const char* text, const char* id, const char* languageCode)
 	:
 	BStringItem(text),
 	fID(id),
@@ -60,8 +59,7 @@ LanguageListItem::DrawItem(BView* owner, BRect frame, bool complete)
 
 
 void
-LanguageListItem::DrawItemWithTextOffset(BView* owner, BRect frame,
-	bool complete, float textOffset)
+LanguageListItem::DrawItemWithTextOffset(BView* owner, BRect frame, bool complete, float textOffset)
 {
 	rgb_color highColor = owner->HighColor();
 	rgb_color lowColor = owner->LowColor();
@@ -76,8 +74,9 @@ LanguageListItem::DrawItemWithTextOffset(BView* owner, BRect frame,
 		owner->SetHighColor(color);
 		owner->SetLowColor(color);
 		owner->FillRect(frame);
-	} else
+	} else {
 		owner->SetLowColor(owner->ViewColor());
+	}
 
 	BString text = Text();
 	if (!IsEnabled()) {
@@ -95,8 +94,7 @@ LanguageListItem::DrawItemWithTextOffset(BView* owner, BRect frame,
 			owner->SetHighColor(ui_color(B_LIST_ITEM_TEXT_COLOR));
 	}
 
-	owner->MovePenTo(
-		frame.left + be_control_look->DefaultLabelSpacing() + textOffset,
+	owner->MovePenTo(frame.left + be_control_look->DefaultLabelSpacing() + textOffset,
 		frame.top + BaselineOffset());
 	owner->DrawString(text.String());
 
@@ -108,8 +106,8 @@ LanguageListItem::DrawItemWithTextOffset(BView* owner, BRect frame,
 // #pragma mark -
 
 
-LanguageListItemWithFlag::LanguageListItemWithFlag(const char* text,
-	const char* id, const char* languageCode, const char* countryCode)
+LanguageListItemWithFlag::LanguageListItemWithFlag(const char* text, const char* id,
+	const char* languageCode, const char* countryCode)
 	:
 	LanguageListItem(text, id, languageCode),
 	fCountryCode(countryCode),
@@ -118,8 +116,7 @@ LanguageListItemWithFlag::LanguageListItemWithFlag(const char* text,
 }
 
 
-LanguageListItemWithFlag::LanguageListItemWithFlag(
-	const LanguageListItemWithFlag& other)
+LanguageListItemWithFlag::LanguageListItemWithFlag(const LanguageListItemWithFlag& other)
 	:
 	LanguageListItem(other),
 	fCountryCode(other.fCountryCode),
@@ -145,10 +142,9 @@ LanguageListItemWithFlag::Update(BView* owner, const BFont* font)
 	if (fCountryCode.IsEmpty())
 		return;
 
-	fIcon = new(std::nothrow) BBitmap(BRect(0, 0, iconSize - 1, iconSize - 1),
-		B_RGBA32);
-	if (fIcon != NULL && BLocaleRoster::Default()->GetFlagIconForCountry(fIcon,
-			fCountryCode.String()) != B_OK) {
+	fIcon = new(std::nothrow) BBitmap(BRect(0, 0, iconSize - 1, iconSize - 1), B_RGBA32);
+	if (fIcon != NULL
+		&& BLocaleRoster::Default()->GetFlagIconForCountry(fIcon, fCountryCode.String()) != B_OK) {
 		delete fIcon;
 		fIcon = NULL;
 	}
@@ -167,8 +163,7 @@ LanguageListItemWithFlag::DrawItem(BView* owner, BRect frame, bool complete)
 	DrawItemWithTextOffset(owner, frame, complete,
 		iconSize + be_control_look->DefaultLabelSpacing());
 
-	BRect iconFrame(frame.left + be_control_look->DefaultLabelSpacing(),
-		frame.top,
+	BRect iconFrame(frame.left + be_control_look->DefaultLabelSpacing(), frame.top,
 		frame.left + iconSize - 1 + be_control_look->DefaultLabelSpacing(),
 		frame.top + iconSize - 1);
 	owner->SetDrawingMode(B_OP_OVER);
@@ -201,8 +196,7 @@ LanguageListItem*
 LanguageListView::ItemForLanguageID(const char* id, int32* _index) const
 {
 	for (int32 index = 0; index < FullListCountItems(); index++) {
-		LanguageListItem* item
-			= static_cast<LanguageListItem*>(FullListItemAt(index));
+		LanguageListItem* item = static_cast<LanguageListItem*>(FullListItemAt(index));
 
 		if (item->ID() == id) {
 			if (_index != NULL)
@@ -219,8 +213,7 @@ LanguageListItem*
 LanguageListView::ItemForLanguageCode(const char* code, int32* _index) const
 {
 	for (int32 index = 0; index < FullListCountItems(); index++) {
-		LanguageListItem* item
-			= static_cast<LanguageListItem*>(FullListItemAt(index));
+		LanguageListItem* item = static_cast<LanguageListItem*>(FullListItemAt(index));
 
 		if (item->Code() == code) {
 			if (_index != NULL)
@@ -273,8 +266,9 @@ LanguageListView::MessageReceived(BMessage* message)
 		dragMessage.AddInt32("drop_index", fDropIndex);
 		dragMessage.AddPointer("drop_target", this);
 		Messenger().SendMessage(&dragMessage);
-	} else
+	} else {
 		BOutlineListView::MessageReceived(message);
+	}
 }
 
 
@@ -288,9 +282,10 @@ LanguageListView::Draw(BRect updateRect)
 		//       into ControlLook
 		BGradientLinear gradient;
 		int step = fGlobalDropTargetIndicator ? 64 : 128;
-		for (int i = 0; i < 256; i += step)
-			gradient.AddColor(i % (step * 2) == 0
-				? ViewColor() : ui_color(B_CONTROL_HIGHLIGHT_COLOR), i);
+		for (int i = 0; i < 256; i += step) {
+			gradient.AddColor(
+				i % (step * 2) == 0 ? ViewColor() : ui_color(B_CONTROL_HIGHLIGHT_COLOR), i);
+		}
 		gradient.AddColor(ViewColor(), 255);
 		gradient.SetStart(fDropTargetHighlightFrame.LeftTop());
 		gradient.SetEnd(fDropTargetHighlightFrame.RightBottom());
@@ -300,15 +295,15 @@ LanguageListView::Draw(BRect updateRect)
 			ConstrainClippingRegion(&region);
 			FillRect(fDropTargetHighlightFrame, gradient);
 			ConstrainClippingRegion(NULL);
-		} else
+		} else {
 			FillRect(fDropTargetHighlightFrame, gradient);
+		}
 	}
 }
 
 
 bool
-LanguageListView::InitiateDrag(BPoint point, int32 dragIndex,
-	bool /*wasSelected*/)
+LanguageListView::InitiateDrag(BPoint point, int32 dragIndex, bool /*wasSelected*/)
 {
 	if (fDragMessage == NULL)
 		return false;
@@ -342,8 +337,7 @@ LanguageListView::InitiateDrag(BPoint point, int32 dragIndex,
 	bool fade = false;
 
 	// figure out, how many items fit into our bitmap
-	for (int32 i = 0, index; message.FindInt32("index", i, &index) == B_OK;
-			i++) {
+	for (int32 i = 0, index; message.FindInt32("index", i, &index) == B_OK; i++) {
 		BListItem* item = ItemAt(index);
 		if (item == NULL)
 			break;
@@ -360,17 +354,15 @@ LanguageListView::InitiateDrag(BPoint point, int32 dragIndex,
 
 	BBitmap* dragBitmap = new BBitmap(dragRect, B_RGB32, true);
 	if (dragBitmap->IsValid()) {
-		BView* view = new BView(dragBitmap->Bounds(), "helper", B_FOLLOW_NONE,
-			B_WILL_DRAW);
+		BView* view = new BView(dragBitmap->Bounds(), "helper", B_FOLLOW_NONE, B_WILL_DRAW);
 		dragBitmap->AddChild(view);
 		dragBitmap->Lock();
-		BRect itemBounds(dragRect) ;
+		BRect itemBounds(dragRect);
 		itemBounds.bottom = 0.0;
 		// let all selected items, that fit into our drag_bitmap, draw
 		for (int32 i = 0; i < numItems; i++) {
 			int32 index = message.FindInt32("index", i);
-			LanguageListItem* item
-				= static_cast<LanguageListItem*>(ItemAt(index));
+			LanguageListItem* item = static_cast<LanguageListItem*>(ItemAt(index));
 			itemBounds.bottom = itemBounds.top + ceilf(item->Height());
 			if (itemBounds.bottom > dragRect.bottom)
 				itemBounds.bottom = dragRect.bottom;
@@ -393,8 +385,7 @@ LanguageListView::InitiateDrag(BPoint point, int32 dragIndex,
 				for (uint8* end = line + 4 * width; line < end; line += 4)
 					*line = ALPHA;
 			}
-			for (int32 y = height - ALPHA / 2; y < height;
-				y++, bits += bpr) {
+			for (int32 y = height - ALPHA / 2; y < height; y++, bits += bpr) {
 				uint8* line = bits + 3;
 				for (uint8* end = line + 4 * width; line < end; line += 4)
 					*line = (height - y) << 1;
@@ -422,8 +413,7 @@ LanguageListView::InitiateDrag(BPoint point, int32 dragIndex,
 
 
 void
-LanguageListView::MouseMoved(BPoint where, uint32 transit,
-	const BMessage* dragMessage)
+LanguageListView::MouseMoved(BPoint where, uint32 transit, const BMessage* dragMessage)
 {
 	if (dragMessage != NULL && _AcceptsDragMessage(dragMessage)) {
 		switch (transit) {
@@ -444,13 +434,13 @@ LanguageListView::MouseMoved(BPoint where, uint32 transit,
 					if (index < 0)
 						index = CountItems();
 					highlightFrame = ItemFrame(index);
-					if (highlightFrame.IsValid())
+					if (highlightFrame.IsValid()) {
 						highlightFrame.bottom = highlightFrame.top;
-					else {
+					} else {
 						highlightFrame = ItemFrame(index - 1);
-						if (highlightFrame.IsValid())
+						if (highlightFrame.IsValid()) {
 							highlightFrame.top = highlightFrame.bottom;
-						else {
+						} else {
 							// empty view, show indicator at top
 							highlightFrame = Bounds();
 							highlightFrame.bottom = highlightFrame.top;
@@ -506,6 +496,5 @@ bool
 LanguageListView::_AcceptsDragMessage(const BMessage* message) const
 {
 	LanguageListView* sourceView = NULL;
-	return message != NULL
-		&& message->FindPointer("listview", (void**)&sourceView) == B_OK;
+	return message != NULL && message->FindPointer("listview", (void**)&sourceView) == B_OK;
 }

--- a/src/LanguageListView.h
+++ b/src/LanguageListView.h
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2006-2010, Haiku Inc. All rights reserved.
+ * Distributed under the terms of the MIT License.
+ *
+ * Authors:
+ *		Stephan Aßmus <superstippi@gmx.de>
+ *		Adrien Destugues <pulkomandy@gmail.com>
+ *		Axel Dörfler, axeld@pinc-software.de
+ *		Oliver Tappe <zooey@hirschkaefer.de>
+ */
+#ifndef LANGUAGE_LIST_VIEW_H
+#define LANGUAGE_LIST_VIEW_H
+
+
+#include <OutlineListView.h>
+#include <StringItem.h>
+#include <String.h>
+
+
+class LanguageListItem : public BStringItem {
+public:
+								LanguageListItem(const char* text,
+									const char* id, const char* languageCode);
+								LanguageListItem(
+									const LanguageListItem& other);
+
+			const BString&		ID() const { return fID; }
+			const BString&		Code() const { return fCode; }
+
+	virtual	void				DrawItem(BView* owner, BRect frame,
+									bool complete = false);
+
+protected:
+			void				DrawItemWithTextOffset(BView* owner,
+									BRect frame, bool complete,
+									float textOffset);
+
+private:
+			BString				fID;
+			BString				fCode;
+};
+
+
+class LanguageListItemWithFlag : public LanguageListItem {
+public:
+								LanguageListItemWithFlag(const char* text,
+									const char* id, const char* languageCode,
+									const char* countryCode = NULL);
+								LanguageListItemWithFlag(
+									const LanguageListItemWithFlag& other);
+	virtual						~LanguageListItemWithFlag();
+
+	virtual void				Update(BView* owner, const BFont* font);
+
+	virtual	void				DrawItem(BView* owner, BRect frame,
+									bool complete = false);
+
+private:
+			BString				fCountryCode;
+			BBitmap*			fIcon;
+};
+
+
+class LanguageListView : public BOutlineListView {
+public:
+								LanguageListView(const char* name,
+									list_view_type type);
+	virtual						~LanguageListView();
+
+			LanguageListItem*	ItemForLanguageID(const char* code,
+									int32* _index = NULL) const;
+			LanguageListItem*	ItemForLanguageCode(const char* code,
+									int32* _index = NULL) const;
+
+			void				SetDeleteMessage(BMessage* message);
+			void				SetDragMessage(BMessage* message);
+			void				SetGlobalDropTargetIndicator(bool isGlobal);
+
+	virtual	void				Draw(BRect updateRect);
+	virtual	bool 				InitiateDrag(BPoint point, int32 index,
+									bool wasSelected);
+	virtual	void 				MouseMoved(BPoint where, uint32 transit,
+									const BMessage* dragMessage);
+	virtual void				MouseUp(BPoint point);
+	virtual	void 				AttachedToWindow();
+	virtual	void 				MessageReceived(BMessage* message);
+	virtual	void				KeyDown(const char* bytes, int32 numBytes);
+
+private:
+			bool				_AcceptsDragMessage(
+									const BMessage* message) const;
+
+private:
+			int32				fDropIndex;
+			BRect				fDropTargetHighlightFrame;
+			bool				fGlobalDropTargetIndicator;
+			BMessage*			fDeleteMessage;
+			BMessage*			fDragMessage;
+};
+
+
+#endif	// LANGUAGE_LIST_VIEW_H

--- a/src/LanguageListView.h
+++ b/src/LanguageListView.h
@@ -13,90 +13,79 @@
 
 
 #include <OutlineListView.h>
-#include <StringItem.h>
 #include <String.h>
+#include <StringItem.h>
 
 
-class LanguageListItem : public BStringItem {
+class LanguageListItem : public BStringItem
+{
 public:
-								LanguageListItem(const char* text,
-									const char* id, const char* languageCode);
-								LanguageListItem(
-									const LanguageListItem& other);
+	LanguageListItem(const char* text, const char* id, const char* languageCode);
+	LanguageListItem(const LanguageListItem& other);
 
-			const BString&		ID() const { return fID; }
-			const BString&		Code() const { return fCode; }
+	const BString& ID() const { return fID; }
+	const BString& Code() const { return fCode; }
 
-	virtual	void				DrawItem(BView* owner, BRect frame,
-									bool complete = false);
+	virtual void DrawItem(BView* owner, BRect frame, bool complete = false);
 
 protected:
-			void				DrawItemWithTextOffset(BView* owner,
-									BRect frame, bool complete,
-									float textOffset);
+	void DrawItemWithTextOffset(BView* owner, BRect frame, bool complete, float textOffset);
 
 private:
-			BString				fID;
-			BString				fCode;
+	BString fID;
+	BString fCode;
 };
 
 
-class LanguageListItemWithFlag : public LanguageListItem {
+class LanguageListItemWithFlag : public LanguageListItem
+{
 public:
-								LanguageListItemWithFlag(const char* text,
-									const char* id, const char* languageCode,
-									const char* countryCode = NULL);
-								LanguageListItemWithFlag(
-									const LanguageListItemWithFlag& other);
-	virtual						~LanguageListItemWithFlag();
+	LanguageListItemWithFlag(const char* text, const char* id, const char* languageCode,
+		const char* countryCode = NULL);
+	LanguageListItemWithFlag(const LanguageListItemWithFlag& other);
+	virtual ~LanguageListItemWithFlag();
 
-	virtual void				Update(BView* owner, const BFont* font);
+	virtual void Update(BView* owner, const BFont* font);
 
-	virtual	void				DrawItem(BView* owner, BRect frame,
-									bool complete = false);
+	virtual void DrawItem(BView* owner, BRect frame, bool complete = false);
 
 private:
-			BString				fCountryCode;
-			BBitmap*			fIcon;
+	BString fCountryCode;
+	BBitmap* fIcon;
 };
 
 
-class LanguageListView : public BOutlineListView {
+class LanguageListView : public BOutlineListView
+{
 public:
-								LanguageListView(const char* name,
-									list_view_type type);
-	virtual						~LanguageListView();
+	LanguageListView(const char* name, list_view_type type);
+	virtual ~LanguageListView();
 
-			LanguageListItem*	ItemForLanguageID(const char* code,
-									int32* _index = NULL) const;
-			LanguageListItem*	ItemForLanguageCode(const char* code,
-									int32* _index = NULL) const;
+	LanguageListItem* ItemForLanguageID(const char* code, int32* _index = NULL) const;
+	LanguageListItem* ItemForLanguageCode(const char* code, int32* _index = NULL) const;
 
-			void				SetDeleteMessage(BMessage* message);
-			void				SetDragMessage(BMessage* message);
-			void				SetGlobalDropTargetIndicator(bool isGlobal);
+	void SetDeleteMessage(BMessage* message);
+	void SetDragMessage(BMessage* message);
+	void SetGlobalDropTargetIndicator(bool isGlobal);
 
-	virtual	void				Draw(BRect updateRect);
-	virtual	bool 				InitiateDrag(BPoint point, int32 index,
-									bool wasSelected);
-	virtual	void 				MouseMoved(BPoint where, uint32 transit,
-									const BMessage* dragMessage);
-	virtual void				MouseUp(BPoint point);
-	virtual	void 				AttachedToWindow();
-	virtual	void 				MessageReceived(BMessage* message);
-	virtual	void				KeyDown(const char* bytes, int32 numBytes);
+	virtual void Draw(BRect updateRect);
+	virtual bool InitiateDrag(BPoint point, int32 index, bool wasSelected);
+	virtual void MouseMoved(BPoint where, uint32 transit, const BMessage* dragMessage);
+	virtual void MouseUp(BPoint point);
+	virtual void AttachedToWindow();
+	virtual void MessageReceived(BMessage* message);
+	virtual void KeyDown(const char* bytes, int32 numBytes);
 
 private:
-			bool				_AcceptsDragMessage(
-									const BMessage* message) const;
+	bool _AcceptsDragMessage(const BMessage* message) const;
 
 private:
-			int32				fDropIndex;
-			BRect				fDropTargetHighlightFrame;
-			bool				fGlobalDropTargetIndicator;
-			BMessage*			fDeleteMessage;
-			BMessage*			fDragMessage;
+	int32 fDropIndex;
+	BRect fDropTargetHighlightFrame;
+	bool fGlobalDropTargetIndicator;
+	BMessage* fDeleteMessage;
+	BMessage* fDragMessage;
 };
 
 
-#endif	// LANGUAGE_LIST_VIEW_H
+#endif // LANGUAGE_LIST_VIEW_H

--- a/src/LocaleView.cpp
+++ b/src/LocaleView.cpp
@@ -1,0 +1,176 @@
+/*
+ * Contains code from Haiku LocaleWindow.h
+ * Copyright 2005-2010, Axel Dörfler, axeld@pinc-software.de.
+ * Copyright 2024, Johan Wagenheim <johan@dospuntos.no>
+ * All rights reserved. Distributed under the terms of the MIT license.
+ */
+
+
+#include "LocaleView.h"
+#include <Catalog.h>
+#include <FormattingConventions.h>
+#include <LayoutBuilder.h>
+#include <NumberFormat.h>
+#include <ScrollView.h>
+#include <Locale.h>
+#include <cstdio>
+#include <Language.h>
+#include "CBLocale.h"
+
+#undef B_TRANSLATION_CONTEXT
+#define B_TRANSLATION_CONTEXT "PrefWindow"
+
+enum {
+	M_NEW_CURRENCY_LOCALE
+};
+
+static int
+compare_typed_list_items(const BListItem* _a, const BListItem* _b)
+{
+	static BCollator collator;
+
+	LanguageListItem* a = (LanguageListItem*)_a;
+	LanguageListItem* b = (LanguageListItem*)_b;
+
+	return collator.Compare(a->Text(), b->Text());
+}
+
+LocaleView::LocaleView(const char* name, const int32& flags)
+	: BView(name, flags)
+{
+	BFormattingConventions initialConventions;
+	BLocale::Default()->GetFormattingConventions(&initialConventions);
+
+	fLocaleBox = new BBox("LocaleBox");
+	UpdateCurrencyLabel(initialConventions);
+
+	fConventionsListView = new LanguageListView("formatting",
+		B_SINGLE_SELECTION_LIST);
+	BScrollView* scrollView = new BScrollView("scroller", fConventionsListView,
+		B_WILL_DRAW | B_FRAME_EVENTS, true, true);
+	fConventionsListView->SetSelectionMessage(
+		new BMessage(M_NEW_CURRENCY_LOCALE));
+
+	// get all available formatting conventions (by language)
+	BMessage availableLanguages;
+	BString conventionsID;
+	fInitialConventionsItem = NULL;
+	LanguageListItem* currentToplevelItem = NULL;
+	if (BLocaleRoster::Default()->GetAvailableLanguages(&availableLanguages)
+			== B_OK) {
+		for (int i = 0;
+			availableLanguages.FindString("language", i, &conventionsID) == B_OK;
+			i++) {
+			BFormattingConventions conventions(conventionsID);
+			BString conventionsName;
+			conventions.GetName(conventionsName);
+
+			LanguageListItem* item;
+			if (conventions.AreCountrySpecific()) {
+				item = new LanguageListItemWithFlag(conventionsName, conventionsID,
+					conventions.LanguageCode(), conventions.CountryCode());
+			} else {
+				item = new LanguageListItem(conventionsName, conventionsID,
+					conventions.LanguageCode());
+			}
+			if (!strcmp(conventionsID, "en_US"))
+				fDefaultConventionsItem = item;
+			if (conventions.AreCountrySpecific()
+				&& currentToplevelItem != NULL
+				&& currentToplevelItem->Code() == item->Code()) {
+				if (!strcmp(conventionsID, initialConventions.ID())) {
+					fConventionsListView->Expand(currentToplevelItem);
+					fInitialConventionsItem = item;
+				}
+				fConventionsListView->AddUnder(item, currentToplevelItem);
+			} else {
+				// This conventions-item isn't country-specific, add it at top-level
+				fConventionsListView->AddItem(item);
+				item->SetExpanded(false);
+				currentToplevelItem = item;
+				if (!strcmp(conventionsID, initialConventions.ID()))
+					fInitialConventionsItem = item;
+			}
+		}
+	} else {
+		ShowAlert(B_TRANSLATE("No available languages"),
+			B_TRANSLATE("CapitalBe couldn't find any available languages. "
+				"You will not be able to set custom currencies."));
+	}
+
+	fConventionsListView->FullListSortItems(compare_typed_list_items);
+	if (fInitialConventionsItem != NULL) {
+		fConventionsListView->Select(fConventionsListView->IndexOf(
+			fInitialConventionsItem));
+	}
+	int size = 21 * be_plain_font->Size();
+	fConventionsListView->SetExplicitMinSize(BSize(size, size));
+
+	BLayoutBuilder::Group<>(fLocaleBox, B_VERTICAL, B_USE_DEFAULT_SPACING)
+		.SetInsets(
+			B_USE_DEFAULT_SPACING, B_USE_BIG_SPACING, B_USE_DEFAULT_SPACING, B_USE_DEFAULT_SPACING)
+		.AddGrid(B_USE_SMALL_SPACING, B_USE_SMALL_SPACING)
+			.Add(scrollView, 0, 0)
+			.End()
+		.End();
+
+	BLayoutBuilder::Group<>(this, B_VERTICAL)
+		.Add(fLocaleBox)
+		.End();
+}
+
+void
+LocaleView::AttachedToWindow(void)
+{
+	fConventionsListView->SetTarget(this);
+}
+
+void
+LocaleView::MessageReceived(BMessage* message)
+{
+	switch (message->what) {
+		case M_NEW_CURRENCY_LOCALE:
+		{
+			// Country selection changed.
+			// Get the new selected country from the ListView and send it to the
+			// main app event handler.
+			void* listView;
+			if (message->FindPointer("source", &listView) != B_OK)
+				break;
+
+			BListView* conventionsList = static_cast<BListView*>(listView);
+			if (conventionsList == NULL)
+				break;
+
+			LanguageListItem* item = static_cast<LanguageListItem*>
+				(conventionsList->ItemAt(conventionsList->CurrentSelection()));
+			if (item == NULL)
+				break;
+
+			BFormattingConventions conventions(item->ID());
+			printf("Convention: %s\n", conventions.CountryCode());
+
+			// _SettingsChanged();
+			UpdateCurrencyLabel(conventions);
+			break;
+		}
+		default:
+			BView::MessageReceived(message);
+			break;
+	}
+}
+
+void
+LocaleView::UpdateCurrencyLabel(BFormattingConventions conventions)
+{
+	BLanguage* language = new BLanguage(conventions.LanguageCode());
+	BLocale* locale = new BLocale(language, &conventions);
+	BNumberFormat numberFormatter(locale);
+	BString curstr;
+
+	if (numberFormatter.FormatMonetary(curstr, 1234567.89) == B_OK) {
+		BString temp;
+		temp.SetToFormat(B_TRANSLATE("Currency format: %s"), curstr.String());
+		fLocaleBox->SetLabel(temp.String());
+	}
+}

--- a/src/LocaleView.cpp
+++ b/src/LocaleView.cpp
@@ -16,6 +16,7 @@
 #include <cstdio>
 #include <Language.h>
 #include "CBLocale.h"
+#include "Database.h"
 
 #undef B_TRANSLATION_CONTEXT
 #define B_TRANSLATION_CONTEXT "PrefWindow"
@@ -38,11 +39,10 @@ compare_typed_list_items(const BListItem* _a, const BListItem* _b)
 LocaleView::LocaleView(const char* name, const int32& flags)
 	: BView(name, flags)
 {
-	BFormattingConventions initialConventions;
-	BLocale::Default()->GetFormattingConventions(&initialConventions);
+	BFormattingConventions initialConventions(gCurrentLocale.AccountLocale());
 
 	fLocaleBox = new BBox("LocaleBox");
-	UpdateCurrencyLabel(initialConventions);
+	UpdateCurrencyLabel(initialConventions.ID());
 
 	fConventionsListView = new LanguageListView("formatting",
 		B_SINGLE_SELECTION_LIST);
@@ -148,10 +148,9 @@ LocaleView::MessageReceived(BMessage* message)
 				break;
 
 			BFormattingConventions conventions(item->ID());
-			printf("Convention: %s\n", conventions.CountryCode());
 
-			// _SettingsChanged();
-			UpdateCurrencyLabel(conventions);
+			fCurrentLocale = conventions.ID();
+			UpdateCurrencyLabel(fCurrentLocale);
 			break;
 		}
 		default:
@@ -161,10 +160,11 @@ LocaleView::MessageReceived(BMessage* message)
 }
 
 void
-LocaleView::UpdateCurrencyLabel(BFormattingConventions conventions)
+LocaleView::UpdateCurrencyLabel(BString code)
 {
-	BLanguage* language = new BLanguage(conventions.LanguageCode());
-	BLocale* locale = new BLocale(language, &conventions);
+	BFormattingConventions conv(code.String());
+	BLanguage* language = new BLanguage(code.String());
+	BLocale* locale = new BLocale(language, &conv);
 	BNumberFormat numberFormatter(locale);
 	BString curstr;
 

--- a/src/LocaleView.cpp
+++ b/src/LocaleView.cpp
@@ -7,23 +7,22 @@
 
 
 #include "LocaleView.h"
-#include <Catalog.h>
-#include <FormattingConventions.h>
-#include <LayoutBuilder.h>
-#include <NumberFormat.h>
-#include <ScrollView.h>
-#include <Locale.h>
-#include <cstdio>
-#include <Language.h>
 #include "CBLocale.h"
 #include "Database.h"
+#include <Catalog.h>
+#include <FormattingConventions.h>
+#include <Language.h>
+#include <LayoutBuilder.h>
+#include <Locale.h>
+#include <NumberFormat.h>
+#include <ScrollView.h>
+#include <cstdio>
 
 #undef B_TRANSLATION_CONTEXT
 #define B_TRANSLATION_CONTEXT "PrefWindow"
 
-enum {
-	M_NEW_CURRENCY_LOCALE
-};
+enum { M_NEW_CURRENCY_LOCALE };
+
 
 static int
 compare_typed_list_items(const BListItem* _a, const BListItem* _b)
@@ -36,31 +35,28 @@ compare_typed_list_items(const BListItem* _a, const BListItem* _b)
 	return collator.Compare(a->Text(), b->Text());
 }
 
+
 LocaleView::LocaleView(const char* name, const int32& flags)
-	: BView(name, flags)
+	:
+	BView(name, flags)
 {
 	BFormattingConventions initialConventions(gCurrentLocale.AccountLocale());
 
 	fLocaleBox = new BBox("LocaleBox");
 	UpdateCurrencyLabel(initialConventions.ID());
 
-	fConventionsListView = new LanguageListView("formatting",
-		B_SINGLE_SELECTION_LIST);
+	fConventionsListView = new LanguageListView("formatting", B_SINGLE_SELECTION_LIST);
 	BScrollView* scrollView = new BScrollView("scroller", fConventionsListView,
 		B_WILL_DRAW | B_FRAME_EVENTS, true, true);
-	fConventionsListView->SetSelectionMessage(
-		new BMessage(M_NEW_CURRENCY_LOCALE));
+	fConventionsListView->SetSelectionMessage(new BMessage(M_NEW_CURRENCY_LOCALE));
 
 	// get all available formatting conventions (by language)
 	BMessage availableLanguages;
 	BString conventionsID;
 	fInitialConventionsItem = NULL;
 	LanguageListItem* currentToplevelItem = NULL;
-	if (BLocaleRoster::Default()->GetAvailableLanguages(&availableLanguages)
-			== B_OK) {
-		for (int i = 0;
-			availableLanguages.FindString("language", i, &conventionsID) == B_OK;
-			i++) {
+	if (BLocaleRoster::Default()->GetAvailableLanguages(&availableLanguages) == B_OK) {
+		for (int i = 0; availableLanguages.FindString("language", i, &conventionsID) == B_OK; i++) {
 			BFormattingConventions conventions(conventionsID);
 			BString conventionsName;
 			conventions.GetName(conventionsName);
@@ -75,8 +71,7 @@ LocaleView::LocaleView(const char* name, const int32& flags)
 			}
 			if (!strcmp(conventionsID, "en_US"))
 				fDefaultConventionsItem = item;
-			if (conventions.AreCountrySpecific()
-				&& currentToplevelItem != NULL
+			if (conventions.AreCountrySpecific() && currentToplevelItem != NULL
 				&& currentToplevelItem->Code() == item->Code()) {
 				if (!strcmp(conventionsID, initialConventions.ID())) {
 					fConventionsListView->Expand(currentToplevelItem);
@@ -95,35 +90,33 @@ LocaleView::LocaleView(const char* name, const int32& flags)
 	} else {
 		ShowAlert(B_TRANSLATE("No available languages"),
 			B_TRANSLATE("CapitalBe couldn't find any available languages. "
-				"You will not be able to set custom currencies."));
+						"You will not be able to set custom currencies."));
 	}
 
 	fConventionsListView->FullListSortItems(compare_typed_list_items);
-	if (fInitialConventionsItem != NULL) {
-		fConventionsListView->Select(fConventionsListView->IndexOf(
-			fInitialConventionsItem));
-	}
+	if (fInitialConventionsItem != NULL)
+		fConventionsListView->Select(fConventionsListView->IndexOf(fInitialConventionsItem));
 	int size = 21 * be_plain_font->Size();
 	fConventionsListView->SetExplicitMinSize(BSize(size, size));
 
 	BLayoutBuilder::Group<>(fLocaleBox, B_VERTICAL, B_USE_DEFAULT_SPACING)
-		.SetInsets(
-			B_USE_DEFAULT_SPACING, B_USE_BIG_SPACING, B_USE_DEFAULT_SPACING, B_USE_DEFAULT_SPACING)
+		.SetInsets(B_USE_DEFAULT_SPACING, B_USE_BIG_SPACING, B_USE_DEFAULT_SPACING,
+			B_USE_DEFAULT_SPACING)
 		.AddGrid(B_USE_SMALL_SPACING, B_USE_SMALL_SPACING)
-			.Add(scrollView, 0, 0)
-			.End()
+		.Add(scrollView, 0, 0)
+		.End()
 		.End();
 
-	BLayoutBuilder::Group<>(this, B_VERTICAL)
-		.Add(fLocaleBox)
-		.End();
+	BLayoutBuilder::Group<>(this, B_VERTICAL).Add(fLocaleBox).End();
 }
+
 
 void
 LocaleView::AttachedToWindow(void)
 {
 	fConventionsListView->SetTarget(this);
 }
+
 
 void
 LocaleView::MessageReceived(BMessage* message)
@@ -142,8 +135,8 @@ LocaleView::MessageReceived(BMessage* message)
 			if (conventionsList == NULL)
 				break;
 
-			LanguageListItem* item = static_cast<LanguageListItem*>
-				(conventionsList->ItemAt(conventionsList->CurrentSelection()));
+			LanguageListItem* item = static_cast<LanguageListItem*>(
+				conventionsList->ItemAt(conventionsList->CurrentSelection()));
 			if (item == NULL)
 				break;
 
@@ -158,6 +151,7 @@ LocaleView::MessageReceived(BMessage* message)
 			break;
 	}
 }
+
 
 void
 LocaleView::UpdateCurrencyLabel(BString code)
@@ -174,3 +168,4 @@ LocaleView::UpdateCurrencyLabel(BString code)
 		fLocaleBox->SetLabel(temp.String());
 	}
 }
+ 

--- a/src/LocaleView.h
+++ b/src/LocaleView.h
@@ -6,26 +6,28 @@
 #define LOCALEWINDOW_H
 
 
+#include "LanguageListView.h"
 #include <Box.h>
 #include <FormattingConventions.h>
 #include <SupportDefs.h>
 #include <View.h>
-#include "LanguageListView.h"
 
 
-class LocaleView : public BView {
+class LocaleView : public BView
+{
 public:
 	LocaleView(const char* name, const int32& flags = B_WILL_DRAW);
-	void 				AttachedToWindow(void);
-	void 				MessageReceived(BMessage* message);
-	void				GetCurrentLocale(BString& currentLocale) { currentLocale = fCurrentLocale; }
+	void AttachedToWindow(void);
+	void MessageReceived(BMessage* message);
+	void GetCurrentLocale(BString& currentLocale) { currentLocale = fCurrentLocale; }
+
 private:
-	LanguageListView*	fConventionsListView;
+	LanguageListView* fConventionsListView;
 	BBox* fLocaleBox;
-	LanguageListItem*	fInitialConventionsItem;
-	LanguageListItem*	fDefaultConventionsItem;
-	void 				UpdateCurrencyLabel(BString code);
-	BString				fCurrentLocale;
+	LanguageListItem* fInitialConventionsItem;
+	LanguageListItem* fDefaultConventionsItem;
+	void UpdateCurrencyLabel(BString code);
+	BString fCurrentLocale;
 };
 
 #endif // _H

--- a/src/LocaleView.h
+++ b/src/LocaleView.h
@@ -18,13 +18,14 @@ public:
 	LocaleView(const char* name, const int32& flags = B_WILL_DRAW);
 	void 				AttachedToWindow(void);
 	void 				MessageReceived(BMessage* message);
+	void				GetCurrentLocale(BString& currentLocale) { currentLocale = fCurrentLocale; }
 private:
 	LanguageListView*	fConventionsListView;
 	BBox* fLocaleBox;
 	LanguageListItem*	fInitialConventionsItem;
 	LanguageListItem*	fDefaultConventionsItem;
-	double				fSampleAmount;
-	void 				UpdateCurrencyLabel(BFormattingConventions conventions);
+	void 				UpdateCurrencyLabel(BString code);
+	BString				fCurrentLocale;
 };
 
 #endif // _H

--- a/src/LocaleView.h
+++ b/src/LocaleView.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024, Johan Wagenheim <johan@dospuntos.no>
+ * All rights reserved. Distributed under the terms of the MIT license.
+ */
+#ifndef LOCALEWINDOW_H
+#define LOCALEWINDOW_H
+
+
+#include <Box.h>
+#include <FormattingConventions.h>
+#include <SupportDefs.h>
+#include <View.h>
+#include "LanguageListView.h"
+
+
+class LocaleView : public BView {
+public:
+	LocaleView(const char* name, const int32& flags = B_WILL_DRAW);
+	void 				AttachedToWindow(void);
+	void 				MessageReceived(BMessage* message);
+private:
+	LanguageListView*	fConventionsListView;
+	BBox* fLocaleBox;
+	LanguageListItem*	fInitialConventionsItem;
+	LanguageListItem*	fDefaultConventionsItem;
+	double				fSampleAmount;
+	void 				UpdateCurrencyLabel(BFormattingConventions conventions);
+};
+
+#endif // _H

--- a/src/PrefWindow.cpp
+++ b/src/PrefWindow.cpp
@@ -7,8 +7,6 @@
 #include <Menu.h>
 #include <MenuItem.h>
 
-#include "Database.h"
-
 
 #undef B_TRANSLATION_CONTEXT
 #define B_TRANSLATION_CONTEXT "PrefWindow"
@@ -40,9 +38,6 @@ PrefWindow::PrefWindow(const BRect& frame)
 	font.SetSize(font.Size() * 1.2f);
 	fLabel->SetFont(&font);
 
-	//fCurrencyPrefView = new CurrencyPrefView("dateview", &gDefaultLocale);
-	fLocaleView = new LocaleView("localeview");
-
 	fOK = new BButton("okbutton", B_TRANSLATE("OK"), new BMessage(M_EDIT_OPTIONS));
 
 	BButton* cancel =
@@ -58,7 +53,6 @@ PrefWindow::PrefWindow(const BRect& frame)
 			.Add(fLabel)
 			.AddGlue()
 			.End()
-		.Add(fLocaleView)
 		.AddGroup(B_HORIZONTAL, B_USE_DEFAULT_SPACING)
 			.AddGlue()
 			.Add(cancel)
@@ -76,13 +70,6 @@ PrefWindow::MessageReceived(BMessage* msg)
 	switch (msg->what) {
 		case M_EDIT_OPTIONS:
 		{
-			Locale temp = gDefaultLocale;
-			fCurrencyPrefView->GetSettings(temp);
-
-			if (temp != gDefaultLocale) {
-				gDefaultLocale = temp;
-				gDatabase.SetDefaultLocale(gDefaultLocale);
-			}
 			PostMessage(B_QUIT_REQUESTED);
 			break;
 		}
@@ -92,135 +79,4 @@ PrefWindow::MessageReceived(BMessage* msg)
 			break;
 		}
 	}
-}
-
-CurrencyPrefView::CurrencyPrefView(const char* name, Locale* locale, const int32& flags)
-	: BView(name, flags),
-	  fSampleAmount((long)12345678, true)
-{
-	BString temp;
-
-	if (locale)
-		fLocale = *locale;
-	else
-		fLocale = gDefaultLocale;
-
-	fCurrencyBox = new BBox("CurrencyBox");
-
-	BString curstr;
-	fLocale.CurrencyToString(fSampleAmount, curstr);
-	temp.SetToFormat(B_TRANSLATE("Currency format: %s"), curstr.String());
-	fCurrencyBox->SetLabel(temp.String());
-
-	fCurrencySymbolBox = new AutoTextControl("moneysym", B_TRANSLATE("Symbol:"),
-		fLocale.CurrencySymbol(), new BMessage(M_NEW_CURRENCY_SYMBOL));
-	fCurrencySymbolBox->SetCharacterLimit(2);
-
-	fCurrencySymbolPrefix = new BCheckBox(
-		"prefixcheck", B_TRANSLATE("Appears before amount"), new BMessage(M_TOGGLE_PREFIX));
-	fCurrencySymbolPrefix->SetValue(
-		(fLocale.IsCurrencySymbolPrefix()) ? B_CONTROL_ON : B_CONTROL_OFF);
-
-	fCurrencySeparatorBox = new AutoTextControl("moneysep", B_TRANSLATE("Separator:"),
-		fLocale.CurrencySeparator(), new BMessage(M_NEW_CURRENCY_SEPARATOR));
-	fCurrencySeparatorBox->SetCharacterLimit(2);
-
-	fCurrencyDecimalBox = new AutoTextControl("moneydecimal", B_TRANSLATE("Decimal:"),
-		fLocale.CurrencyDecimal(), new BMessage(M_NEW_CURRENCY_DECIMAL));
-	fCurrencyDecimalBox->SetCharacterLimit(2);
-
-	// clang-format off
-	BLayoutBuilder::Group<>(fCurrencyBox, B_VERTICAL, B_USE_DEFAULT_SPACING)
-		.SetInsets(
-			B_USE_DEFAULT_SPACING, B_USE_BIG_SPACING, B_USE_DEFAULT_SPACING, B_USE_DEFAULT_SPACING)
-		.AddGrid(B_USE_SMALL_SPACING, B_USE_SMALL_SPACING)
-			.Add(fCurrencySymbolBox->CreateLabelLayoutItem(), 0, 0)
-			.Add(fCurrencySymbolBox->CreateTextViewLayoutItem(), 1, 0)
-			.Add(fCurrencySymbolPrefix, 2, 0, 3, 1)
-			.Add(fCurrencySeparatorBox->CreateLabelLayoutItem(), 0, 1)
-			.Add(fCurrencySeparatorBox->CreateTextViewLayoutItem(), 1, 1)
-			.Add(fCurrencyDecimalBox->CreateLabelLayoutItem(), 2, 1)
-			.Add(fCurrencyDecimalBox->CreateTextViewLayoutItem(), 3, 1)
-			.AddGlue(4, 1)
-			.End()
-		.End();
-
-	BLayoutBuilder::Group<>(this, B_VERTICAL)
-		.Add(fCurrencyBox)
-		.End();
-	// clang-format on
-}
-
-void
-CurrencyPrefView::AttachedToWindow(void)
-{
-	fCurrencySymbolBox->SetTarget(this);
-	fCurrencyDecimalBox->SetTarget(this);
-	fCurrencySeparatorBox->SetTarget(this);
-	fCurrencySymbolPrefix->SetTarget(this);
-}
-
-void
-CurrencyPrefView::MessageReceived(BMessage* msg)
-{
-	switch (msg->what) {
-		case M_NEW_CURRENCY_SYMBOL:
-		{
-			if (strlen(fCurrencySymbolBox->Text()) < 1)
-				break;
-
-			fLocale.SetCurrencySymbol(fCurrencySymbolBox->Text());
-			UpdateCurrencyLabel();
-			break;
-		}
-		case M_NEW_CURRENCY_SEPARATOR:
-		{
-			if (strlen(fCurrencySeparatorBox->Text()) < 1)
-				break;
-
-			fLocale.SetCurrencySeparator(fCurrencySeparatorBox->Text());
-			UpdateCurrencyLabel();
-			break;
-		}
-		case M_NEW_CURRENCY_DECIMAL:
-		{
-			if (strlen(fCurrencyDecimalBox->Text()) < 1)
-				break;
-
-			fLocale.SetCurrencyDecimal(fCurrencyDecimalBox->Text());
-			UpdateCurrencyLabel();
-			break;
-		}
-		case M_TOGGLE_PREFIX:
-		{
-			fLocale.SetCurrencySymbolPrefix(fCurrencySymbolPrefix->Value() == B_CONTROL_ON);
-			UpdateCurrencyLabel();
-			break;
-		}
-		default:
-			BView::MessageReceived(msg);
-			break;
-	}
-}
-
-void
-CurrencyPrefView::UpdateCurrencyLabel(void)
-{
-	BString temp, label;
-	fLocale.CurrencyToString(fSampleAmount, temp);
-	label.SetToFormat(B_TRANSLATE("Currency format: %s"), temp.String());
-	fCurrencyBox->SetLabel(label.String());
-}
-
-void
-CurrencyPrefView::GetSettings(Locale& locale)
-{
-	if (strlen(fCurrencySeparatorBox->Text()) > 0)
-		locale.SetCurrencySeparator(fCurrencySeparatorBox->Text());
-	if (strlen(fCurrencyDecimalBox->Text()) > 0)
-		locale.SetCurrencyDecimal(fCurrencyDecimalBox->Text());
-	if (strlen(fCurrencySymbolBox->Text()) > 0)
-		locale.SetCurrencySymbol(fCurrencySymbolBox->Text());
-
-	locale.SetCurrencySymbolPrefix(fCurrencySymbolPrefix->Value() == B_CONTROL_ON);
 }

--- a/src/PrefWindow.cpp
+++ b/src/PrefWindow.cpp
@@ -40,7 +40,8 @@ PrefWindow::PrefWindow(const BRect& frame)
 	font.SetSize(font.Size() * 1.2f);
 	fLabel->SetFont(&font);
 
-	fCurrencyPrefView = new CurrencyPrefView("dateview", &gDefaultLocale);
+	//fCurrencyPrefView = new CurrencyPrefView("dateview", &gDefaultLocale);
+	fLocaleView = new LocaleView("localeview");
 
 	fOK = new BButton("okbutton", B_TRANSLATE("OK"), new BMessage(M_EDIT_OPTIONS));
 
@@ -57,7 +58,7 @@ PrefWindow::PrefWindow(const BRect& frame)
 			.Add(fLabel)
 			.AddGlue()
 			.End()
-		.Add(fCurrencyPrefView)
+		.Add(fLocaleView)
 		.AddGroup(B_HORIZONTAL, B_USE_DEFAULT_SPACING)
 			.AddGlue()
 			.Add(cancel)

--- a/src/PrefWindow.h
+++ b/src/PrefWindow.h
@@ -15,8 +15,8 @@
 #include "AutoTextControl.h"
 #include "CBLocale.h"
 #include "Fixed.h"
+#include "LocaleView.h"
 
-class DatePrefView;
 class CurrencyPrefView;
 
 class PrefWindow : public BWindow {
@@ -26,6 +26,7 @@ public:
 
 private:
 	CurrencyPrefView* fCurrencyPrefView;
+	LocaleView* fLocaleView;
 	BButton* fOK;
 	BStringView* fLabel;
 };

--- a/src/QuickTrackerItem.cpp
+++ b/src/QuickTrackerItem.cpp
@@ -81,7 +81,7 @@ QTNetWorthItem::HandleNotify(const uint64& value, const BMessage* msg)
 					Window()->Lock();
 
 				BString label, temp;
-				temp << B_TRANSLATE("Balance") << " (" << gDefaultLocale.CurrencySymbol() << "): ";
+				temp << B_TRANSLATE("Balance") << ": ";
 				if (gCurrentLocale.CurrencyToString(Fixed(), label) == B_OK)
 					temp << label;
 				SetText(temp.String());
@@ -120,7 +120,8 @@ QTNetWorthItem::Calculate(void)
 
 
 	// Get list of currencies
-	command = "SELECT DISTINCT currencysymbol FROM accountlocale";
+	// Todo: Update database table
+	command = "SELECT DISTINCT dateformat FROM accountlocale";
 	query = gDatabase.DBQuery(command.String(), "Database::Calculate");
 
 	while (!query.eof()) {
@@ -145,15 +146,14 @@ QTNetWorthItem::Calculate(void)
 	}
 
 	if (accountsFound && gDefaultLocale.CurrencyToString(balance, balanceText) == B_OK) {
-		balanceLabel << B_TRANSLATE("Balance") << " (" << gDefaultLocale.CurrencySymbol()
-					 << "): " << balanceText << "\n";
+		balanceLabel << B_TRANSLATE("Balance") << ": " << balanceText << "\n";
 	}
 
 	// Get sum of other currency accounts:
 	for (int32 i = 0; i < currencies.size(); i++) {
 		command =
 			"SELECT a1.accountid FROM accountlist AS a1 JOIN accountlocale AS a2 ON "
-			"a1.accountid=a2.accountid WHERE a2.currencysymbol = \"";
+			"a1.accountid=a2.accountid WHERE a2.dateformat = \"";
 		command << currencies.at(i) << "\" AND a1.status = \"Open\";";
 		query = gDatabase.DBQuery(command.String(), "Database::Calculate");
 
@@ -168,8 +168,7 @@ QTNetWorthItem::Calculate(void)
 		}
 
 		if (accLocale.CurrencyToString(balance, balanceText) == B_OK) {
-			balanceLabel << B_TRANSLATE("Balance") << " (" << accLocale.CurrencySymbol()
-						 << "): " << balanceText << "\n";
+			balanceLabel << B_TRANSLATE("Balance") << ": " << balanceText << "\n";
 		}
 	}
 


### PR DESCRIPTION
This PR enables currency display using the settings from Haiku's locale system. Currencies are displayed in the default system format, and can be customized for each account on creation or by editing account settings.

![currency-locale](https://github.com/HaikuArchives/CapitalBe/assets/12958546/d8879437-598c-4513-b4c9-43c07a59076b)

Known issues:
- Some unused code from previous system is still left
- `Locale::StringToCurrency` function is not working properly for languages with `.` as thousand-separator (e.g. €1.234,56)
- The program settings window is currently empty, but will get some color settings soon from @humdingerb :)