### PR TITLE
Show alternate colours in Transaction view

### DIFF
--- a/src/Preferences.cpp
+++ b/src/Preferences.cpp
@@ -87,6 +87,10 @@ GetMutedTint(const rgb_color color, const CapitalBeMuted& type)
 		{
 			return IsDark(color) ? B_LIGHTEN_2_TINT : B_DARKEN_1_TINT;
 		}
+		case CB_ALT_ROW:
+		{
+			return IsDark(color) ? 0.94 : 1.05;
+		}
 		default:
 			return B_NO_TINT;
 	}

--- a/src/Preferences.h
+++ b/src/Preferences.h
@@ -19,7 +19,8 @@ status_t LoadPreferences(const char* path);
 
 typedef enum {
 	CB_MUTED_TEXT = 0,
-	CB_MUTED_BG
+	CB_MUTED_BG,
+	CB_ALT_ROW
 } CapitalBeMuted;
 
 const float GetMutedTint(const rgb_color color, const CapitalBeMuted& type);

--- a/src/TransactionItem.cpp
+++ b/src/TransactionItem.cpp
@@ -42,14 +42,17 @@ TransactionItem::DrawItem(BView* owner, BRect frame, bool complete)
 	BString string;
 	Locale locale = fAccount->GetLocale();
 
+	BListView* list = (BListView*)owner;
+	int32 index = list->IndexOf(this);
+
 	BRect r(frame);
-	r.right--;
 
 	if (IsSelected()) {
 		owner->SetHighUIColor(B_LIST_SELECTED_BACKGROUND_COLOR);
 		owner->FillRect(frame);
 		owner->SetHighUIColor(
 			fStatus == TRANS_RECONCILED ? B_TOOL_TIP_BACKGROUND_COLOR : B_CONTROL_HIGHLIGHT_COLOR);
+		frame.bottom--;
 		owner->StrokeRect(frame);
 	} else if (fStatus == TRANS_RECONCILED) {
 		owner->SetHighUIColor(
@@ -58,9 +61,16 @@ TransactionItem::DrawItem(BView* owner, BRect frame, bool complete)
 		owner->SetHighUIColor(B_CONTROL_TEXT_COLOR);
 		owner->StrokeLine(r.LeftBottom(), r.RightBottom());
 	} else {
-		owner->SetHighUIColor(B_CONTROL_TEXT_COLOR);
-		owner->StrokeLine(r.LeftBottom(), r.RightBottom());
+		if (index % 2 == 1) { // darken odd row
+			owner->SetHighUIColor(
+				B_LIST_BACKGROUND_COLOR, GetMutedTint(ui_color(B_LIST_BACKGROUND_COLOR), CB_ALT_ROW));
+		} else
+			owner->SetHighUIColor(B_LIST_BACKGROUND_COLOR);
+
+		owner->FillRect(frame);
 	}
+	owner->SetHighUIColor(B_CONTROL_TEXT_COLOR);
+	owner->StrokeLine(r.LeftBottom(), r.RightBottom());
 
 	float textTint = B_NO_TINT;
 	rgb_color textColor;


### PR DESCRIPTION
* Lighten/darken every other transaction item for better orientation. Reuses GetMutedTint() with a new type CB_ALT_ROW.

* Fix a slightly off drawing of the selected stroked frame. Always draw the bottom line, also for selected items. Before, horizontal lines were a pixel short at the right. Fixed after removing the "r.right--"...

Screenshots:

Before:
![before](https://github.com/HaikuArchives/CapitalBe/assets/6107158/0e45d705-ef58-4617-acf1-640d932f604b)

After:
![altcolor](https://github.com/HaikuArchives/CapitalBe/assets/6107158/f1f89fab-3734-46fe-81d0-9512a73b94ac)

