### PR TITLE
Use locale kit for number formatting

### DIFF
--- a/locales/en.catkeys
+++ b/locales/en.catkeys
@@ -1,4 +1,4 @@
-1	English	application/x-vnd.wgp-CapitalBe	3882412825
+1	English	application/x-vnd.wgp-CapitalBe	1546978192
 Year	ReportWindow		Year
 None	ReportWindow		None
 Export to QIF file…	MainWindow		Export to QIF file…
@@ -25,7 +25,6 @@ Import from QIF file…	MainWindow		Import from QIF file…
 Preview:	PrefWindow		Preview:
 Ending date:	ReportWindow		Ending date:
 Scheduled transactions	MainWindow		Scheduled transactions
-Separator:	PrefWindow		Separator:
 Closed account:	PrefWindow		Closed account:
 Help: Report	ReportWindow		Help: Report
 Bank charges	ReconcileWindow		Bank charges
@@ -50,6 +49,7 @@ Highest	BudgetWindow		Highest
 You need to have at least 2 accounts to perform a transfer.	MainWindow		You need to have at least 2 accounts to perform a transfer.
 Monthly	ScheduleListWindow		Monthly
 Frequency	BudgetWindow		Frequency
+Decimals:	PrefWindow		Decimals:
 CapitalBe didn't understand the amount for 'Bank charges'	ReconcileWindow		CapitalBe didn't understand the amount for 'Bank charges'
 You need to enter a check number or transaction type, such as ATM (for debit card transactions and the like), DEP (for deposits), or your own code for some other kind of expense.	CheckView		You need to enter a check number or transaction type, such as ATM (for debit card transactions and the like), DEP (for deposits), or your own code for some other kind of expense.
 Uncategorized	SplitView		Uncategorized
@@ -70,8 +70,8 @@ Interest earned	ReconcileWindow		Interest earned
 Quit	Locale		Quit
 Once deleted, you will not be able to get back any data on this account.	MainWindow		Once deleted, you will not be able to get back any data on this account.
 Add category	CategoryWindow		Add category
+Use system currency format	Account		Use system currency format
 Could not export your financial data to the file '%%FILENAME%%'	MainWindow		Could not export your financial data to the file '%%FILENAME%%'
-Currency format:	PrefWindow		Currency format:
 Name:	Account		Name:
 Total deposits: %s	ReconcileWindow		Total deposits: %s
 Memo	CommonTerms		Memo
@@ -160,7 +160,6 @@ Total checks:	ReconcileWindow		Total checks:
 Remove item	SplitView		Remove item
 Transaction	MainWindow		Transaction
 Edit transfer	TransferWindow		Edit transfer
-Default account settings	PrefWindow		Default account settings
 Reports	MainWindow		Reports
 Categories	CategoryWindow		Categories
 Account	MainWindow		Account
@@ -169,6 +168,7 @@ Unselected:	PrefWindow		Unselected:
 Total deposits:	ReconcileWindow		Total deposits:
 Categories…	MainWindow		Categories…
 Help: Budget	BudgetWindow		Help: Budget
+Currency format	PrefWindow		Currency format
 Payee	CommonTerms		Payee
 If you intend to transfer money, it will need to be an amount that is not zero.	TransferWindow		If you intend to transfer money, it will need to be an amount that is not zero.
 You can schedule transfers, deposits, or ATM transactions.	MainWindow		You can schedule transfers, deposits, or ATM transactions.
@@ -208,7 +208,6 @@ Starting date:	ReportWindow		Starting date:
 Starting balance	ReconcileWindow		Starting balance
 Quarterly	ScheduleAddWindow		Quarterly
 Reconcile:	ReconcileWindow		Reconcile:
-Use default currency settings	Account		Use default currency settings
 Total charges:	ReconcileWindow		Total charges:
 Total worth	ReportWindow		Total worth
 Expense	CashFlowReport		Expense
@@ -228,7 +227,6 @@ Total checks: %s	ReconcileWindow		Total checks: %s
 Quarterly	BudgetWindow		Quarterly
 Remove category	CategoryWindow		Remove category
 You cannot schedule transactions on a closed account.	MainWindow		You cannot schedule transactions on a closed account.
-Decimal:	PrefWindow		Decimal:
 CapitalBe didn't understand the amount for 'Interest earned'	ReconcileWindow		CapitalBe didn't understand the amount for 'Interest earned'
 Date is missing	ReconcileWindow		Date is missing
 Unknown	ScheduleListWindow		Unknown

--- a/src/Account.cpp
+++ b/src/Account.cpp
@@ -322,14 +322,12 @@ Account::UseDefaultLocale(const bool& usedefault)
 
 	BString command;
 	if (fUseDefaultLocale) {
-		command = "delete from accountlocale where accountid = ";
-		command << fID << ";";
+		command << "DELETE FROM accountlocale WHERE accountid = " << fID << ";";
 		gDatabase.DBCommand(command.String(), "Account::UseDefaultLocale");
 		gCurrentLocale = gDefaultLocale;
 	} else {
 		// update the local copy in case it changed since the program was opened
-		fLocale = gDefaultLocale;
-
+		fLocale = gCurrentLocale;
 		gDatabase.SetAccountLocale(fID, fLocale);
 	}
 

--- a/src/Account.h
+++ b/src/Account.h
@@ -20,25 +20,19 @@ public:
 	~Account(void);
 
 	void SetName(const char* name);
-
 	const char* Name(void) const { return fName.String(); }
 
 	void SetID(const time_t& id) { fID = id; }
-
 	uint32 GetID(void) const { return fID; }
 
 	void SetClosed(const bool& value) { fClosed = value; }
-
 	bool IsClosed(void) const { return fClosed; }
 
 	uint32 CurrentTransaction(void) const { return fCurrentTransaction; }
-
 	bool SetCurrentTransaction(const uint32& id);
 
 	uint16 LastCheckNumber(void) const { return fLastCheckNumber; }
-
 	uint16 LookupLastCheckNumber(void);
-
 	void SetLastCheckNumber(const uint16& value) { fLastCheckNumber = value; }
 
 	BString AutocompleteCategory(const char* input);
@@ -58,7 +52,6 @@ public:
 		void (*TransactionIteratorFunc)(const TransactionData&, void*), void* ptr);
 
 	void UseDefaultLocale(const bool& usedefault);
-
 	bool IsUsingDefaultLocale(void) const { return fUseDefaultLocale; }
 
 private:

--- a/src/AccountSettingsWindow.cpp
+++ b/src/AccountSettingsWindow.cpp
@@ -8,7 +8,6 @@
 #include "Database.h"
 #include "PrefWindow.h"
 
-
 #undef B_TRANSLATION_CONTEXT
 #define B_TRANSLATION_CONTEXT "Account"
 
@@ -35,7 +34,7 @@ AccountSettingsWindow::AccountSettingsWindow(Account* account)
 		(fAccount ? fAccount->Name() : NULL), new BMessage(M_NAME_CHANGED));
 	fAccountName->SetCharacterLimit(32);
 
-	fUseDefault = new BCheckBox("usedefault", B_TRANSLATE("Use default currency settings"),
+	fUseDefault = new BCheckBox("usedefault", B_TRANSLATE("Use system currency format"),
 		new BMessage(M_TOGGLE_USE_DEFAULT));
 	if (!fAccount || fAccount->IsUsingDefaultLocale())
 		fUseDefault->SetValue(B_CONTROL_ON);
@@ -55,9 +54,9 @@ AccountSettingsWindow::AccountSettingsWindow(Account* account)
 
 	SetDefaultButton(fOK);
 
-	if (!fAccount || fAccount->IsUsingDefaultLocale()) {
+	if (!fAccount || fAccount->IsUsingDefaultLocale())
 		fPrefView->Hide();
-	}
+
 	// clang-format off
 	BLayoutBuilder::Group<>(this, B_VERTICAL, B_USE_DEFAULT_SPACING)
 		.SetInsets(B_USE_DEFAULT_SPACING)
@@ -86,17 +85,15 @@ AccountSettingsWindow::MessageReceived(BMessage* msg)
 		case M_EDIT_ACCOUNT_SETTINGS:
 		{
 			Locale customLocale;
-			Locale defaultLocale;
+			fPrefView->GetSettings(customLocale);
 
 			if (!fAccount) {
-				fPrefView->GetSettings(customLocale);
 				gDatabase.AddAccount(fAccountName->Text(), ACCOUNT_BANK, "Open",
-					defaultLocale == customLocale ? NULL : &customLocale);
+					fUseDefault->Value() == B_CONTROL_ON ? NULL : &customLocale);
 			} else {
 				if (strcmp(fAccountName->Text(), fAccount->Name()) != 0)
 					gDatabase.RenameAccount(fAccount, fAccountName->Text());
 
-				fPrefView->GetSettings(customLocale);
 				if (fUseDefault->Value() != B_CONTROL_ON) {
 					fAccount->UseDefaultLocale(false);
 					fAccount->SetLocale(customLocale);

--- a/src/BudgetWindow.cpp
+++ b/src/BudgetWindow.cpp
@@ -5,6 +5,7 @@
 #include <LayoutBuilder.h>
 #include <MenuBar.h>
 #include <Message.h>
+#include <NumberFormat.h>
 #include <StringView.h>
 
 #include "Account.h"
@@ -44,6 +45,8 @@ BudgetWindow::BudgetWindow(const BRect& frame)
 	  fIncomeGrid(13, 0),
 	  fSpendingGrid(13, 0)
 {
+	BNumberFormat numberFormatter;
+	fDecimalSymbol = numberFormatter.GetSeparator(B_DECIMAL_SEPARATOR);
 	fBar = new BMenuBar("menubar");
 	fBar->AddItem(
 		new BMenuItem(B_TRANSLATE("Recalculate all"), new BMessage(M_BUDGET_RECALCULATE)));
@@ -128,7 +131,7 @@ BudgetWindow::MessageReceived(BMessage* msg)
 				break;
 			f.Round();
 			gDefaultLocale.CurrencyToString(f, str);
-			str.Truncate(str.FindFirst(gDefaultLocale.CurrencyDecimal()));
+			str.Truncate(str.FindFirst(fDecimalSymbol));
 			str.RemoveFirst(gDefaultLocale.CurrencySymbol());
 
 			BRow* row = fCategoryList->CurrentSelection();
@@ -251,7 +254,7 @@ BudgetWindow::HandleCategorySelection(void)
 
 	BString str;
 	gDefaultLocale.CurrencyToString(entry.amount.AbsoluteValue(), str);
-	str.Truncate(str.FindFirst(gDefaultLocale.CurrencyDecimal()));
+	str.Truncate(str.FindFirst(fDecimalSymbol));
 	str.RemoveFirst(gDefaultLocale.CurrencySymbol());
 	fAmountBox->SetText(str.String());
 
@@ -306,7 +309,7 @@ BudgetWindow::RefreshCategories(void)
 
 		BString amountstr;
 		gDefaultLocale.CurrencyToString(amount.AbsoluteValue(), amountstr);
-		amountstr.Truncate(amountstr.FindFirst(gDefaultLocale.CurrencyDecimal()));
+		amountstr.Truncate(amountstr.FindFirst(fDecimalSymbol));
 		amountstr.RemoveFirst(gDefaultLocale.CurrencySymbol());
 
 		row->SetField(new BStringField(amountstr.String()), 1);
@@ -355,9 +358,9 @@ BudgetWindow::RefreshBudgetSummary(void)
 		gDefaultLocale.CurrencyToString(stotal, stemp);
 		gDefaultLocale.CurrencyToString(mtotal, mtemp);
 
-		itemp.Truncate(itemp.FindFirst(gDefaultLocale.CurrencyDecimal()));
-		stemp.Truncate(stemp.FindFirst(gDefaultLocale.CurrencyDecimal()));
-		mtemp.Truncate(mtemp.FindFirst(gDefaultLocale.CurrencyDecimal()));
+		itemp.Truncate(itemp.FindFirst(fDecimalSymbol));
+		stemp.Truncate(stemp.FindFirst(fDecimalSymbol));
+		mtemp.Truncate(mtemp.FindFirst(fDecimalSymbol));
 
 		itemp.RemoveFirst(gDefaultLocale.CurrencySymbol());
 		stemp.RemoveFirst(gDefaultLocale.CurrencySymbol());
@@ -387,17 +390,17 @@ BudgetWindow::RefreshBudgetSummary(void)
 	BString ttemp;
 
 	gDefaultLocale.CurrencyToString(irowtotal, ttemp);
-	ttemp.Truncate(ttemp.FindFirst(gDefaultLocale.CurrencyDecimal()));
+	ttemp.Truncate(ttemp.FindFirst(fDecimalSymbol));
 	ttemp.RemoveFirst(gDefaultLocale.CurrencySymbol());
 	fBudgetSummary->RowAt(0)->SetField(new BStringField(ttemp.String()), 13);
 
 	gDefaultLocale.CurrencyToString(srowtotal, ttemp);
-	ttemp.Truncate(ttemp.FindFirst(gDefaultLocale.CurrencyDecimal()));
+	ttemp.Truncate(ttemp.FindFirst(fDecimalSymbol));
 	ttemp.RemoveFirst(gDefaultLocale.CurrencySymbol());
 	fBudgetSummary->RowAt(1)->SetField(new BStringField(ttemp.String()), 13);
 
 	gDefaultLocale.CurrencyToString(ttotal, ttemp);
-	ttemp.Truncate(ttemp.FindFirst(gDefaultLocale.CurrencyDecimal()));
+	ttemp.Truncate(ttemp.FindFirst(fDecimalSymbol));
 	ttemp.RemoveFirst(gDefaultLocale.CurrencySymbol());
 	fBudgetSummary->RowAt(2)->SetField(new BStringField(ttemp.String()), 13);
 
@@ -670,7 +673,7 @@ BudgetWindow::SetPeriod(const BudgetPeriod& period)
 
 	BString str;
 	gDefaultLocale.CurrencyToString(entry.amount, str);
-	str.Truncate(str.FindFirst(gDefaultLocale.CurrencyDecimal()));
+	str.Truncate(str.FindFirst(fDecimalSymbol));
 	str.RemoveFirst(gDefaultLocale.CurrencySymbol());
 
 	row->SetField(new BStringField(str.String()), 1);

--- a/src/BudgetWindow.h
+++ b/src/BudgetWindow.h
@@ -57,6 +57,7 @@ private:
 	BRow *fStatAverageRow, *fStatHighestRow, *fStatLowestRow;
 
 	ReportGrid fIncomeGrid, fSpendingGrid;
+	BString fDecimalSymbol;
 };
 
 #endif

--- a/src/CBLocale.h
+++ b/src/CBLocale.h
@@ -8,11 +8,6 @@
 #include "DAlert.h"
 #include "Fixed.h"
 
-typedef enum {
-	DATE_MDY = 1,
-	DATE_DMY = 2
-} date_format;
-
 class Locale {
 public:
 	Locale(void);
@@ -31,42 +26,22 @@ public:
 	void NumberToCurrency(const Fixed& number, BString& string);
 
 	void SetCurrencySymbol(const char* symbol);
-
 	const char* CurrencySymbol(void) const { return fCurrencySymbol.String(); }
 
-	void SetCurrencySeparator(const char* symbol);
-
-	const char* CurrencySeparator(void) const { return fCurrencySeparator.String(); }
-
-	void SetCurrencyDecimal(const char* symbol);
-
-	const char* CurrencyDecimal(void) const { return fCurrencyDecimal.String(); }
-
 	void SetCurrencySymbolPrefix(const bool& value);
-
 	bool IsCurrencySymbolPrefix(void) const { return fPrefixSymbol; }
 
-	void SetCurrencyDecimalPlace(const uint8& place);
-
+	void SetCurrencyDecimalPlace(const uint8 place);
 	uint8 CurrencyDecimalPlace(void) const { return fCurrencyDecimalPlace; }
-
-	void SetDST(const bool& value);
-
-	bool UseDST(void) const { return fUseDST; }
 
 private:
 	friend class CapitalBeParser;
 
 	void SetDefaults(void);
-	status_t ConstructDateStringMDY(const char* in, BString& out);
-	status_t ConstructDateStringDMY(const char* in, BString& out);
 
 	BString fCurrencySymbol;
 	bool fPrefixSymbol;
-	BString fCurrencySeparator;
-	BString fCurrencyDecimal;
 	uint8 fCurrencyDecimalPlace;
-	bool fUseDST;
 };
 
 void ShowAlert(const char* header, const char* message, alert_type type = B_INFO_ALERT);

--- a/src/Database.h
+++ b/src/Database.h
@@ -69,7 +69,6 @@ public:
 
 	void SetAccountLocale(const uint32& accountid, const Locale& data);
 	Locale LocaleForAccount(const uint32& id);
-	void SetDefaultLocale(const Locale& data);
 	Locale GetDefaultLocale(void);
 	bool UsesDefaultLocale(const uint32& id);
 

--- a/src/PrefWindow.h
+++ b/src/PrefWindow.h
@@ -8,6 +8,7 @@
 #include <MenuField.h>
 #include <Message.h>
 #include <RadioButton.h>
+#include <Spinner.h>
 #include <String.h>
 #include <StringView.h>
 #include <View.h>
@@ -29,13 +30,7 @@ enum {
 };
 
 // CurrencyPrefView
-enum {
-	M_NEW_CURRENCY_SYMBOL,
-	M_NEW_CURRENCY_SEPARATOR,
-	M_NEW_CURRENCY_DECIMAL,
-	M_TOGGLE_PREFIX,
-	M_CURRENCY_UPADTED
-};
+enum { M_NEW_CURRENCY_SYMBOL, M_TOGGLE_PREFIX, M_CURRENCY_UPDATED, M_CURRENCY_DECIMAL_PLACE };
 
 // NegativeNumberView
 enum {
@@ -70,8 +65,9 @@ private:
 	void UpdateCurrencyLabel(void);
 
 	BBox* fCurrencyBox;
-	AutoTextControl *fCurrencySymbolBox, *fCurrencyDecimalBox, *fCurrencySeparatorBox;
+	AutoTextControl* fCurrencySymbolBox;
 	BCheckBox* fCurrencySymbolPrefix;
+	BSpinner* fDecimalSpinner;
 	BStringView* fCurrencyPreview;
 	Locale fLocale;
 	Fixed fSampleAmount;
@@ -88,7 +84,6 @@ public:
 	void GetColor(rgb_color& color);
 
 private:
-	void UpdateText(BString text);
 	void UpdateColor(rgb_color color);
 
 	BColorControl* fColorPicker;

--- a/src/QuickTrackerItem.cpp
+++ b/src/QuickTrackerItem.cpp
@@ -81,7 +81,7 @@ QTNetWorthItem::HandleNotify(const uint64& value, const BMessage* msg)
 					Window()->Lock();
 
 				BString label, temp;
-				temp << B_TRANSLATE("Balance") << " (" << gDefaultLocale.CurrencySymbol() << "): ";
+				temp << B_TRANSLATE("Balance") << ": ";
 				if (gCurrentLocale.CurrencyToString(Fixed(), label) == B_OK)
 					temp << label;
 				SetText(temp.String());
@@ -145,8 +145,7 @@ QTNetWorthItem::Calculate(void)
 	}
 
 	if (accountsFound && gDefaultLocale.CurrencyToString(balance, balanceText) == B_OK) {
-		balanceLabel << B_TRANSLATE("Balance") << " (" << gDefaultLocale.CurrencySymbol()
-					 << "): " << balanceText << "\n";
+		balanceLabel << B_TRANSLATE("Balance") << ": " << balanceText << "\n";
 	}
 
 	// Get sum of other currency accounts:
@@ -168,8 +167,7 @@ QTNetWorthItem::Calculate(void)
 		}
 
 		if (accLocale.CurrencyToString(balance, balanceText) == B_OK) {
-			balanceLabel << B_TRANSLATE("Balance") << " (" << accLocale.CurrencySymbol()
-						 << "): " << balanceText << "\n";
+			balanceLabel << B_TRANSLATE("Balance") << ": " << balanceText << "\n";
 		}
 	}
 


### PR DESCRIPTION
New PR, the long country list has been removed. Fixes #8.

- The monetary formatting from the Haiku locale kit is used by default.
- A custom currency symbol can be set, but the number itself is still formatted using the locale kit
- Remove unused code and methods
- Change some of the SQL queries to uppercase for easier reading