### PR TITLE
More bug fixes

### DIFF
--- a/locales/en.catkeys
+++ b/locales/en.catkeys
@@ -1,4 +1,4 @@
-1	English	application/x-vnd.wgp-CapitalBe	1546978192
+1	English	application/x-vnd.wgp-CapitalBe	338110697
 Year	ReportWindow		Year
 None	ReportWindow		None
 Export to QIF file…	MainWindow		Export to QIF file…
@@ -165,6 +165,7 @@ Categories	CategoryWindow		Categories
 Account	MainWindow		Account
 Uncategorized	CategoryWindow		Uncategorized
 Unselected:	PrefWindow		Unselected:
+{0, plural,one{This account has # scheduled transaction that will be removed.}other{This account has # scheduled transactions that will be removed.}}	MainWindow		{0, plural,one{This account has # scheduled transaction that will be removed.}other{This account has # scheduled transactions that will be removed.}}
 Total deposits:	ReconcileWindow		Total deposits:
 Categories…	MainWindow		Categories…
 Help: Budget	BudgetWindow		Help: Budget

--- a/src/BudgetReport.cpp
+++ b/src/BudgetReport.cpp
@@ -139,7 +139,6 @@ ReportWindow::ComputeBudget(void)
 	// Later this will iterate over all items in the category list
 	BStringItem* stringitem = (BStringItem*)fCategoryList->ItemAt(0);
 	if (!stringitem) {
-		ShowBug("NULL category BStringItem in ReportWindow::ComputeBudget");
 		return;
 	}
 

--- a/src/BudgetReport.cpp
+++ b/src/BudgetReport.cpp
@@ -138,9 +138,8 @@ ReportWindow::ComputeBudget(void)
 
 	// Later this will iterate over all items in the category list
 	BStringItem* stringitem = (BStringItem*)fCategoryList->ItemAt(0);
-	if (!stringitem) {
+	if (stringitem == NULL)
 		return;
-	}
 
 	BudgetEntry budgetentry;
 

--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -1088,6 +1088,19 @@ Database::CountScheduledTransactions(void)
 	return query.getInt64Field(0);
 }
 
+uint32
+Database::CountScheduledTransactions(int accountid)
+{
+	BString command;
+	command << "SELECT COUNT(*) FROM scheduledlist WHERE accountid = " << accountid;
+	CppSQLite3Query query = gDatabase.DBQuery(command.String(), "Database::CountScheduledTransactions");
+
+	if (query.eof())
+		return 0;
+
+	return query.getInt64Field(0);
+}
+
 bool
 Database::InsertSchedTransaction(const uint32& id, const uint32& accountid, const time_t& startdate,
 	const TransactionType& type, const char* payee, const Fixed& amount, const char* category,

--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -379,9 +379,15 @@ Database::RemoveAccount(const int& accountid)
 		command << accountid << ";";
 		DBCommand(command.String(), "Database::RemoveAccount:delete accountlocale item");
 
+		command = "DELETE FROM scheduledlist WHERE accountid = ";
+		command << accountid << ";";
+		DBCommand(command.String(), "Database::RemoveAccount:delete scheduled items");
+
 		command = "DROP TABLE account_";
 		command << accountid;
 		DBCommand(command.String(), "Database::RemoveAccount:drop account table");
+
+
 
 		fList.RemoveItem(item);
 		if (fList.CountItems() == 0)

--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -192,7 +192,7 @@ Database::OpenFile(const char* path)
 		BString name = DeescapeIllegalCharacters(query.getStringField(1));
 		BString status = DeescapeIllegalCharacters(query.getStringField(3));
 
-		Account* account = new Account(name.String(), status.ICompare("open") != 0);
+		Account* account = new Account(name.String(), status.ICompare("Open") != 0);
 		account->SetID(id);
 		if (!UsesDefaultLocale(id)) {
 			Locale accountLocale = LocaleForAccount(id);

--- a/src/Database.h
+++ b/src/Database.h
@@ -89,6 +89,7 @@ public:
 	void RemoveScheduledTransaction(const uint32& id);
 	bool GetScheduledTransaction(const uint32& transid, ScheduledTransData& data);
 	uint32 CountScheduledTransactions(void);
+	uint32 CountScheduledTransactions(int accountid);
 
 	void AddCategory(const char* name, const bool& isexpense);
 	void RemoveCategory(const char* name);

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -11,6 +11,7 @@
 #include <Path.h>
 #include <Resources.h>
 #include <Roster.h>
+#include <StringFormat.h>
 #include <Url.h>
 #include <private/interface/AboutWindow.h>
 
@@ -264,9 +265,21 @@ MainWindow::MessageReceived(BMessage* msg)
 			if (!acc)
 				break;
 
+			uint32 scheduledTransactions = gDatabase.CountScheduledTransactions(acc->GetID());
+			BString msg;
+			if (scheduledTransactions > 0) {
+
+				static BStringFormat format(B_TRANSLATE("{0, plural,"
+					"one{This account has # scheduled transaction that will be removed.}"
+					"other{This account has # scheduled transactions that will be removed.}}"));
+				format.Format(msg, scheduledTransactions);
+				msg << "\n\n";
+		   }
+
+		   msg << B_TRANSLATE("Once deleted, you will not be able to get back any data on this account.");
+
 			DAlert* alert = new DAlert(B_TRANSLATE("Really delete account?"),
-				B_TRANSLATE("Once deleted, you will not be able to "
-							"get back any data on this account."),
+                               msg.String(),
 				B_TRANSLATE("Delete"), B_TRANSLATE("Cancel"), NULL, B_WIDTH_AS_USUAL, B_STOP_ALERT);
 
 			if (alert->Go() == 0) {

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -168,6 +168,8 @@ MainWindow::MainWindow(BRect frame)
 	// clang-format on
 
 	HandleScheduledTransactions();
+	BMessage message(M_RUN_SCHEDULED_TRANSACTIONS);
+	fRunner = new BMessageRunner(this, &message, 30 * 1000 * 1000); // Every 30 seconds
 }
 
 MainWindow::~MainWindow(void)
@@ -502,6 +504,11 @@ MainWindow::MessageReceived(BMessage* msg)
 			ScheduleAddWindow* schedwin = new ScheduleAddWindow(r, data);
 			schedwin->CenterIn(Frame());
 			schedwin->Show();
+			break;
+		}
+		case M_RUN_SCHEDULED_TRANSACTIONS:
+		{
+			HandleScheduledTransactions();
 			break;
 		}
 		case M_CREATE_TRANSFER:

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -6,6 +6,7 @@
 #include <Menu.h>
 #include <MenuItem.h>
 #include <Message.h>
+#include <MessageRunner.h>
 #include <String.h>
 #include <Window.h>
 #include "Database.h"
@@ -49,7 +50,8 @@ enum {
 	M_SHOW_ABOUT = 'msha',
 	M_SHOW_REPORTS_WINDOW,
 	M_SHOW_OPTIONS_WINDOW,
-	M_SHOW_SCHEDULED_WINDOW
+	M_SHOW_SCHEDULED_WINDOW,
+	M_RUN_SCHEDULED_TRANSACTIONS
 };
 
 class MainWindow : public BWindow, public Observer {
@@ -74,6 +76,7 @@ private:
 
 	BString fLastFile;
 	BMenuItem* fAccountClosedItem;
+	BMessageRunner* fRunner;
 
 	bool fLoadError;
 };

--- a/src/NetWorthReport.cpp
+++ b/src/NetWorthReport.cpp
@@ -54,7 +54,6 @@ ReportWindow::ComputeNetWorth(void)
 	timelist.AddItem(new time_t(fEndDate));
 
 	ReportGrid accountgrid(1, timelist.CountItems());
-
 	BString longestname(B_TRANSLATE("Total worth"));
 	int longestnamelength = longestname.CountChars();
 
@@ -89,37 +88,35 @@ ReportWindow::ComputeNetWorth(void)
 		accountgrid.SetValue(0, subtotal_index, accounttotal);
 	}
 
-	if (fGraphView->IsHidden()) {
-		// Now that we have all the data, we need to set up the rows and columns for the report grid
+	// Now that we have all the data, we need to set up the rows and columns for the report grid
 
-		BColumn* col = new BStringColumn(B_TRANSLATE_CONTEXT("Date", "CommonTerms"),
-			fGridView->StringWidth(longestname.String()) + 20, 10, 300, B_TRUNCATE_END);
-		fGridView->AddColumn(col, 0);
-		col = new BStringColumn(B_TRANSLATE("Total"), 75, 10, 300, B_TRUNCATE_END);
-		fGridView->AddColumn(col, 1);
+	BColumn* col = new BStringColumn(B_TRANSLATE_CONTEXT("Date", "CommonTerms"),
+		fGridView->StringWidth(longestname.String()) + 20, 10, 300, B_TRUNCATE_END);
+	fGridView->AddColumn(col, 0);
+	col = new BStringColumn(B_TRANSLATE("Total"), 75, 10, 300, B_TRUNCATE_END);
+	fGridView->AddColumn(col, 1);
 
-		fGridView->AddRow(new BRow());
-		BRow* titlerow = new BRow();
-		fGridView->AddRow(titlerow);
-		titlerow->SetField(new BStringField(B_TRANSLATE("Total worth")), 0);
-		fGridView->AddRow(new BRow());
+	fGridView->AddRow(new BRow());
+	BRow* titlerow = new BRow();
+	fGridView->AddRow(titlerow);
+	titlerow->SetField(new BStringField(B_TRANSLATE("Total worth")), 0);
+	fGridView->AddRow(new BRow());
 
-		// Now that the grid is set up, start adding data to the grid
-		for (int32 rowindex = 0; rowindex < accountgrid.CountItems(); rowindex++) {
-			BRow* row = new BRow();
-			fGridView->AddRow(row);
+	// Now that the grid is set up, start adding data to the grid
+	for (int32 rowindex = 0; rowindex < accountgrid.CountItems(); rowindex++) {
+		BRow* row = new BRow();
+		fGridView->AddRow(row);
 
-			BStringField* catname = new BStringField(accountgrid.RowTitle(rowindex));
-			row->SetField(catname, 0);
+		BStringField* catname = new BStringField(accountgrid.RowTitle(rowindex));
+		row->SetField(catname, 0);
 
-			BString temp;
-			Fixed f;
+		BString temp;
+		Fixed f;
 
-			accountgrid.ValueAt(0, rowindex, f);
-			gCurrentLocale.CurrencyToString(f, temp);
+		accountgrid.ValueAt(0, rowindex, f);
+		gCurrentLocale.CurrencyToString(f, temp);
 
-			BStringField* amountfield = new BStringField(temp.String());
-			row->SetField(amountfield, 1);
-		}
+		BStringField* amountfield = new BStringField(temp.String());
+		row->SetField(amountfield, 1);
 	}
 }

--- a/src/ScheduleAddWindow.cpp
+++ b/src/ScheduleAddWindow.cpp
@@ -16,6 +16,7 @@
 #include "Database.h"
 #include "DateBox.h"
 #include "NumBox.h"
+#include "ScheduledExecutor.h"
 #include "ScheduledTransData.h"
 
 
@@ -269,6 +270,8 @@ ScheduleAddWindow::MessageReceived(BMessage* msg)
 				gDatabase.GetTransferCounterpart(stdata.GetID(), stdata);
 				gDatabase.AddScheduledTransaction(stdata);
 			}
+
+			HandleScheduledTransactions();
 
 			PostMessage(B_QUIT_REQUESTED);
 			break;

--- a/src/ScheduleListWindow.cpp
+++ b/src/ScheduleListWindow.cpp
@@ -83,6 +83,7 @@ ScheduleListView::ScheduleListView(const char* name, const int32& flags)
 	float maxwidth = RefreshScheduleList();
 	fBestWidth = (fRemoveButton->Frame().Width() * 2) + 45;
 	fBestWidth = MAX(fBestWidth, maxwidth + 35);
+	fBestWidth = MAX(fBestWidth, 400);
 
 	HelpButton* helpButton =
 		new HelpButton(B_TRANSLATE("Help: Scheduled transaction"), "Scheduled Transaction.txt");


### PR DESCRIPTION
Fixing some more bugs and crashes.

Also adding a warning when deleting accounts with scheduled transactions, and making sure schedules are run when created and every 30 seconds (fixes #74 ). [edited]

- Remove scheduled transactions when account is deleted
- Run scheduled transactions when added and every 30 seconds [edited]
- Fix crash in report window
- Show warning about scheduled transactions
- Set Scheduled win min width
- Fixes #78 - QuickTracker

![schedule-warning](https://github.com/HaikuArchives/CapitalBe/assets/12958546/f5942f5e-5561-44a5-adcd-4acafa2a417d)
