### PR TITLE
DateBox filter: Improved shortcuts

### DIFF
--- a/helpfiles/en/Main Window.txt
+++ b/helpfiles/en/Main Window.txt
@@ -18,7 +18,7 @@ Entering a Transaction
 
 Adding a transaction to an account is just as simple as typing in information into the form in the bottom right part of the window and hitting the Enter key or clicking the Enter button.
 
-Tip: The + and - keys can change the date by one day. The Page Up and Page Down keys change it by one month.
+Tip: The Up or Down arrow can change the date by one day. Add the Shift keys to change the month. The Page Up and Page Down keys change the year.
 Tip: Jump to the next box with the Tab key or jump to the previous one with Shift + Tab.
 
 The QuickTracker Panel

--- a/src/DateBox.cpp
+++ b/src/DateBox.cpp
@@ -38,57 +38,44 @@ DateBoxFilter::KeyFilter(const int32& key, const int32& mod)
 	}
 #endif
 
-	//	if(key == B_ESCAPE && !IsEscapeCancel())
-	//		return B_SKIP_MESSAGE;
-
 	// Weed out navigation keys
-	if ((key < 32 && key != B_PAGE_UP && key != B_PAGE_DOWN))
+	if (key < 32 && key != B_PAGE_UP && key != B_PAGE_DOWN
+			&& key != B_UP_ARROW && key != B_DOWN_ARROW)
 		return B_DISPATCH_MESSAGE;
 
 	int32 start, end;
 	DateBox* box = (DateBox*)TextControl();
 	box->TextView()->GetSelection(&start, &end);
 
-	BString keystring;
-	GetCurrentMessage()->FindString("bytes", &keystring);
-
 	BString string;
-	if (keystring == "+") {
-		if (strlen(box->Text()) > 0)
-			box->fCurrentDate = IncrementDateByDay(box->fCurrentDate);
-
-		gDefaultLocale.DateToString(box->fCurrentDate, string);
-		box->SetText(string.String());
-		box->TextView()->SelectAll();
-		TextControl()->Invoke();
-		return B_SKIP_MESSAGE;
-	} else if (key == B_PAGE_UP) {
+	if (key == B_UP_ARROW) {
 		if (strlen(box->Text()) > 0) {
 			if (mod & B_SHIFT_KEY)
-				box->fCurrentDate = IncrementDateByYear(box->fCurrentDate);
-			else
 				box->fCurrentDate = IncrementDateByMonth(box->fCurrentDate);
+			else
+				box->fCurrentDate = IncrementDateByDay(box->fCurrentDate);
 		}
-		gDefaultLocale.DateToString(box->fCurrentDate, string);
-		box->SetText(string.String());
-		box->TextView()->SelectAll();
-		TextControl()->Invoke();
-		return B_SKIP_MESSAGE;
-	} else if (key == B_PAGE_DOWN) {
+	} else if (key == B_DOWN_ARROW) {
 		if (strlen(box->Text()) > 0) {
 			if (mod & B_SHIFT_KEY)
-				box->fCurrentDate = DecrementDateByYear(box->fCurrentDate);
-			else
 				box->fCurrentDate = DecrementDateByMonth(box->fCurrentDate);
+			else
+				box->fCurrentDate = DecrementDateByDay(box->fCurrentDate);
 		}
-		gDefaultLocale.DateToString(box->fCurrentDate, string);
-		box->SetText(string.String());
-		box->TextView()->SelectAll();
-		TextControl()->Invoke();
-		return B_SKIP_MESSAGE;
-	}
+	} else if (key == B_PAGE_UP) {
+		if (strlen(box->Text()) > 0)
+			box->fCurrentDate = IncrementDateByYear(box->fCurrentDate);
+	} else if (key == B_PAGE_DOWN) {
+		if (strlen(box->Text()) > 0)
+			box->fCurrentDate = DecrementDateByYear(box->fCurrentDate);
+	} else
+		return B_DISPATCH_MESSAGE;
 
-	return B_DISPATCH_MESSAGE;
+	gDefaultLocale.DateToString(box->fCurrentDate, string);
+	box->SetText(string.String());
+	box->TextView()->SelectAll();
+	TextControl()->Invoke();
+	return B_SKIP_MESSAGE;
 }
 
 DateBox::DateBox(const char* name, const char* label, const char* text, BMessage* msg, uint32 flags)


### PR DESCRIPTION
"+" used to increase the day. There was no "-" to decrease, because that may be used as date delimiter(?).

I think this change makes the shortcuts more intuitive:
* CursorUp/Down : in/decrease day
* SHIFT+CursorUp/Down : in/decrease month
* PageUp/Down : in/decrease year

In/decreasing the year is only seldomly used, so it's fine to have it on a less commonly used shortcut. In/decreasing the day/month is handy much more often and is therefore on the most familiar cursor keys.

Updated help file accordingly.

This change also reduces code duplication.