### PR TITLE
Scheduled transaction: Add "Memo" column

### DIFF
--- a/locales/en.catkeys
+++ b/locales/en.catkeys
@@ -1,4 +1,4 @@
-1	English	application/x-vnd.wgp-CapitalBe	338110697
+1	English	application/x-vnd.wgp-CapitalBe	2441433350
 Year	ReportWindow		Year
 None	ReportWindow		None
 Export to QIF file…	MainWindow		Export to QIF file…
@@ -220,7 +220,6 @@ Amount	CommonTerms		Amount
 Quick balance failed. This doesn't mean that you did something wrong - it's just that 'Quick balance' works on simpler cases in balancing an account than this one. Sorry.	ReconcileWindow		Quick balance failed. This doesn't mean that you did something wrong - it's just that 'Quick balance' works on simpler cases in balancing an account than this one. Sorry.
 You need to have an account created in order to reconcile it.	MainWindow		You need to have an account created in order to reconcile it.
 Payee is missing	TextInput		Payee is missing
-Next Payment	ScheduleListWindow		Next Payment
 CapitalBe didn't understand the date you entered	TextInput		CapitalBe didn't understand the date you entered
 Recalculate all	BudgetWindow		Recalculate all
 Split transaction	SplitView		Split transaction
@@ -232,3 +231,4 @@ CapitalBe didn't understand the amount for 'Interest earned'	ReconcileWindow		Ca
 Date is missing	ReconcileWindow		Date is missing
 Unknown	ScheduleListWindow		Unknown
 Category	CommonTerms		Category
+Memo	ScheduleListWindow		Memo

--- a/src/ScheduleListWindow.cpp
+++ b/src/ScheduleListWindow.cpp
@@ -68,18 +68,20 @@ ScheduleListView::ScheduleListView(const char* name, const int32& flags)
 	float amountwidth = StringWidth("$000,000.00");
 	float amountlabelwidth = StringWidth(B_TRANSLATE_CONTEXT("Amount", "CommonTerms"));
 	fListView->AddColumn(new BStringColumn(B_TRANSLATE_CONTEXT("Amount", "CommonTerms"),
-							 MAX(amountwidth, amountlabelwidth), 25, 300, B_ALIGN_LEFT),
+							 MAX(amountwidth, amountlabelwidth) + 20, 25, 300, B_ALIGN_LEFT),
 		1);
 	fListView->AddColumn(new BStringColumn(B_TRANSLATE("Payments"),
-							 StringWidth(B_TRANSLATE("Payments")) + 20, 25, 300, B_ALIGN_LEFT),
+							 StringWidth(B_TRANSLATE("Payments")) + 30, 25, 300, B_ALIGN_LEFT),
 		2);
 	fListView->AddColumn(new BStringColumn(B_TRANSLATE("Frequency"),
-							 StringWidth(B_TRANSLATE("Frequency")) + 20, 25, 300, B_ALIGN_LEFT),
+							 StringWidth(B_TRANSLATE("Frequency")) + 30, 25, 300, B_ALIGN_LEFT),
 		3);
-	fListView->AddColumn(new BStringColumn(B_TRANSLATE("Next Payment"),
+	fListView->AddColumn(new BStringColumn(B_TRANSLATE("Next payment"),
 							 StringWidth(B_TRANSLATE("Next payment")) + 20, 25, 300, B_ALIGN_LEFT),
 		4);
-
+	fListView->AddColumn(new BStringColumn(B_TRANSLATE("Memo"),
+							StringWidth("This is a relatively long memo text"), 25, 300, B_ALIGN_LEFT),
+		5);
 	float maxwidth = RefreshScheduleList();
 	fBestWidth = (fRemoveButton->Frame().Width() * 2) + 45;
 	fBestWidth = MAX(fBestWidth, maxwidth + 35);
@@ -255,6 +257,9 @@ ScheduleListView::RefreshScheduleList(void)
 		// next pay date
 		gDefaultLocale.DateToString(sdata->GetNextDueDate(), string);
 		row->SetField(new BStringField(string.String()), 4);
+
+		// memo
+		row->SetField(new BStringField(DeescapeIllegalCharacters(sdata->Memo())), 5);
 	}
 
 	fListView->ColumnAt(0)->SetWidth(maxwidth + 30);


### PR DESCRIPTION
* The memo of every scheduled transaction usually provides important information. No reason not showing it.

* Slightly wider columns, esp. for the amount, to avoid truncation.

* Fixed typo in column label.

* Updated en.catkeys