### PR TITLE
Deescape memo in split view and scheduled list

### DIFF
--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -1070,13 +1070,13 @@ Database::GetScheduledTransaction(const uint32& transid, ScheduledTransData& dat
 		data.AddCategory(DeescapeIllegalCharacters(query.getStringField(4)).String(), f, true);
 
 		if (!query.fieldIsNull(4))
-			data.SetMemoAt(data.CountCategories() - 1, query.getStringField(5));
+			data.SetMemoAt(data.CountCategories() - 1, DeescapeIllegalCharacters(query.getStringField(5)));
 
 		query.nextRow();
 	}
 
 	if ((data.CountCategories() == 1) && strlen(data.MemoAt(0)) > 0)
-		data.SetMemo(data.MemoAt(0));
+		data.SetMemo(DeescapeIllegalCharacters(data.MemoAt(0)));
 
 	UNLOCK;
 	return true;
@@ -1126,9 +1126,9 @@ Database::InsertSchedTransaction(const uint32& id, const uint32& accountid, cons
 
 	BString command = "INSERT INTO scheduledlist VALUES(";
 	command << timestamp << ", " << accountid << ", " << id << ", " << startdate << ",'"
-			<< type.Type() << "', '" << epayee << "', " << amount.AsFixed() << ", '" << ecategory;
+			<< type.Type() << "', '" << epayee.String() << "', " << amount.AsFixed() << ", '" << ecategory.String();
 	if (memo)
-		command << "', '" << ememo << "', ";
+		command << "', '" << ememo.String() << "', ";
 	else
 		command << "', '', ";
 

--- a/src/ScheduleListWindow.cpp
+++ b/src/ScheduleListWindow.cpp
@@ -17,10 +17,8 @@
 #include "ColumnTypes.h"
 #include "Database.h"
 #include "HelpButton.h"
-#include "Preferences.h"
 #include "ScheduledTransData.h"
 #include "ScheduledTransItem.h"
-#include "TransactionLayout.h"
 
 
 #undef B_TRANSLATION_CONTEXT

--- a/src/SplitView.cpp
+++ b/src/SplitView.cpp
@@ -156,7 +156,7 @@ SplitView::SplitView(const char* name, const TransactionData& trans, const int32
 		SplitItem* item = new SplitItem();
 		item->SetCategory(fTransaction.NameAt(i));
 		item->SetAmount(fTransaction.AmountAt(i));
-		item->SetMemo(fTransaction.MemoAt(i));
+		item->SetMemo(DeescapeIllegalCharacters(fTransaction.MemoAt(i)));
 
 		fSplitItems->AddItem(item);
 	}
@@ -495,7 +495,7 @@ SplitView::MessageReceived(BMessage* msg)
 			gCurrentLocale.CurrencyToString(item->GetAmount().AbsoluteValue(), amount);
 			fSplitAmount->SetText(amount.String());
 
-			fSplitMemo->SetText(item->GetMemo());
+			fSplitMemo->SetText(DeescapeIllegalCharacters(item->GetMemo()));
 			fSplitCategory->TextView()->SelectAll();
 			break;
 		}


### PR DESCRIPTION
Fixes #75 by deescaping the memo. Also fixes a similar issue with memos in split transactions.