### PR TITLE
Show warning on failed QIF import

### DIFF
--- a/locales/en.catkeys
+++ b/locales/en.catkeys
@@ -1,6 +1,7 @@
-1	English	application/x-vnd.wgp-CapitalBe	2441433350
+1	English	application/x-vnd.wgp-CapitalBe	3892464343
 Year	ReportWindow		Year
 None	ReportWindow		None
+Credit Card Account 	Import		Credit Card Account 
 Export to QIF file…	MainWindow		Export to QIF file…
 Reports	ReportWindow		Reports
 Monthly	ScheduleAddWindow		Monthly
@@ -85,17 +86,20 @@ There may be a typo or the wrong kind of currency symbol for this account.	TextI
 Repeat:	ScheduleAddWindow		Repeat:
 Appears before amount	PrefWindow		Appears before amount
 Unreconciled total: %s	ReconcileWindow		Unreconciled total: %s
+Uncategorized	Import		Uncategorized
 Couldn't Quick balance	ReconcileWindow		Couldn't Quick balance
 There may be a typo or the wrong kind of currency symbol for this account.	ReconcileWindow		There may be a typo or the wrong kind of currency symbol for this account.
 Really delete account?	MainWindow		Really delete account?
 DEP	ReconcileWindow		DEP
-Quick balance	ReconcileWindow		Quick balance
 Remove	ScheduleListWindow		Remove
+Cash Account	Import		Cash Account
+Quick balance	ReconcileWindow		Quick balance
 This happens when the kind of file is not supported, when the file's data is damaged, or when you feed it a recipe for quiche.	MainWindow		This happens when the kind of file is not supported, when the file's data is damaged, or when you feed it a recipe for quiche.
-Month	ReportWindow		Month
 Payments	ScheduleListWindow		Payments
+Month	ReportWindow		Month
 No memo	TransactionEdit		No memo
 Closed	Account		Closed
+[No payee entered]	Import		[No payee entered]
 Delete	MainWindow		Delete
 From account:	TransferWindow		From account:
 Quick balance successful!	ReconcileWindow		Quick balance successful!
@@ -188,6 +192,7 @@ Add	CategoryWindow		Add
 Quit	MainWindow		Quit
 Lowest	BudgetWindow		Lowest
 Previous	MainWindow		Previous
+Bank Account	Import		Bank Account
 Transaction type is missing	CheckView		Transaction type is missing
 Accounts	RegisterView		Accounts
 Amount	ScheduleAddWindow		Amount

--- a/src/Import.cpp
+++ b/src/Import.cpp
@@ -9,6 +9,7 @@
 #include "TextFile.h"
 #include "Transaction.h"
 #include "TransactionData.h"
+#include <Catalog.h>
 #include <File.h>
 #include <TypeConstants.h>
 #include <stdio.h>
@@ -21,6 +22,9 @@
 #else
 #define STRACE(x) /* */
 #endif
+
+#undef B_TRANSLATION_CONTEXT
+#define B_TRANSLATION_CONTEXT "Import"
 
 bool debuggerflag = false;
 
@@ -70,24 +74,21 @@ ImportQIF(const entry_ref& ref)
 		} else if (string.FindFirst("!Type:Bank") != B_ERROR) {
 			STRACE(("Bank Account\n"));
 			accountindex++;
-			accountname = "Bank Account ";
-			accountname << accountindex;
+			accountname.SetToFormat("<%s %i>", B_TRANSLATE("Bank account"), accountindex);
 
 			currentaccount = gDatabase.AddAccount(accountname.String(), ACCOUNT_BANK, "Open");
 			string = ReadTransactions(currentaccount, file);
 			importSuccess = true;
 		} else if (string.FindFirst("!Type:Cash") != B_ERROR) {
 			accountindex++;
-			accountname = "Cash Account ";
-			accountname << accountindex;
+			accountname.SetToFormat("<%s %i>", B_TRANSLATE("Cash account"), accountindex);
 
 			currentaccount = gDatabase.AddAccount(accountname.String(), ACCOUNT_CASH, "Open");
 			string = ReadTransactions(currentaccount, file);
 			importSuccess = true;
 		} else if (string.FindFirst("!Type:CCard") != B_ERROR) {
 			accountindex++;
-			accountname = "Credit Card Account ";
-			accountname << accountindex;
+			accountname.SetToFormat("<%s %i>", B_TRANSLATE("Credit card account"), accountindex);
 
 			currentaccount = gDatabase.AddAccount(accountname.String(), ACCOUNT_CREDIT, "Open");
 			string = ReadTransactions(currentaccount, file);
@@ -167,8 +168,7 @@ ReadCategories(BObjectList<Category>& list, TextFile& file)
 		catdata.RemoveAll("\r");
 	}
 	delete cat;
-
-	STRACE(("Added %ld categories\n", list.CountItems()));
+	//STRACE(("Added %i categories\n", list.CountItems()));
 	return catdata;
 }
 
@@ -321,11 +321,11 @@ ReadTransactions(Account* account, TextFile& file)
 					if (data.Amount().AsLong() == 0)
 						break;
 					else
-						data.SetPayee("[No Payee Entered]");
+						data.SetPayee(B_TRANSLATE("<No payee entered>"));
 				}
 
 				if (data.CountCategories() < 1)
-					data.SetCategory("Uncategorized");
+					data.SetCategory(B_TRANSLATE("<Uncategorized>"));
 
 
 				gDatabase.AddTransaction(data);

--- a/src/Import.cpp
+++ b/src/Import.cpp
@@ -1,9 +1,4 @@
 #include "Import.h"
-#include <File.h>
-#include <TypeConstants.h>
-#include <stdio.h>
-#include <time.h>
-#include <string>
 #include "Account.h"
 #include "Budget.h"
 #include "CBLocale.h"
@@ -14,6 +9,10 @@
 #include "TextFile.h"
 #include "Transaction.h"
 #include "TransactionData.h"
+#include <File.h>
+#include <TypeConstants.h>
+#include <stdio.h>
+#include <time.h>
 
 #define DEBUG_IMPORT
 
@@ -52,6 +51,7 @@ ImportQIF(const entry_ref& ref)
 	BObjectList<Category> catlist(20);
 	BObjectList<Account> accountlist(20);
 	int32 accountindex = 0;
+	bool importSuccess = false;
 
 	BString string = file.ReadLine();
 
@@ -66,28 +66,32 @@ ImportQIF(const entry_ref& ref)
 
 		if (string.FindFirst("!Type:Cat") != B_ERROR) {
 			string = ReadCategories(catlist, file);
+			importSuccess = true;
 		} else if (string.FindFirst("!Type:Bank") != B_ERROR) {
 			STRACE(("Bank Account\n"));
 			accountindex++;
 			accountname = "Bank Account ";
 			accountname << accountindex;
 
-			currentaccount = gDatabase.AddAccount(accountname.String(), ACCOUNT_BANK, "open");
+			currentaccount = gDatabase.AddAccount(accountname.String(), ACCOUNT_BANK, "Open");
 			string = ReadTransactions(currentaccount, file);
+			importSuccess = true;
 		} else if (string.FindFirst("!Type:Cash") != B_ERROR) {
 			accountindex++;
 			accountname = "Cash Account ";
 			accountname << accountindex;
 
-			currentaccount = gDatabase.AddAccount(accountname.String(), ACCOUNT_CASH, "open");
+			currentaccount = gDatabase.AddAccount(accountname.String(), ACCOUNT_CASH, "Open");
 			string = ReadTransactions(currentaccount, file);
+			importSuccess = true;
 		} else if (string.FindFirst("!Type:CCard") != B_ERROR) {
 			accountindex++;
 			accountname = "Credit Card Account ";
 			accountname << accountindex;
 
-			currentaccount = gDatabase.AddAccount(accountname.String(), ACCOUNT_CREDIT, "open");
+			currentaccount = gDatabase.AddAccount(accountname.String(), ACCOUNT_CREDIT, "Open");
 			string = ReadTransactions(currentaccount, file);
+			importSuccess = true;
 		}
 		/*		else
 				if(string=="!Account")
@@ -114,7 +118,7 @@ ImportQIF(const entry_ref& ref)
 		}
 	}
 
-	return true;
+	return importSuccess;
 }
 
 BString


### PR DESCRIPTION
Is this enough to close #5 ?

It is just a basic check if anything was imported. QIF-files are simple text files, and the import script runs through each line looking for something to import. If nothing is found, it now returns `false` and displays a message.

Attached is a small QIF file for testing.

[1_qif_example.qif.txt](https://github.com/user-attachments/files/15878515/1_qif_example.qif.txt)
