### PR TITLE
Adding Category selection button

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ SRCS = \
 	 src/CashFlowReport.cpp  \
 	 src/Category.cpp  \
 	 src/CategoryBox.cpp  \
+	 src/CategoryButton.cpp\
 	 src/CategoryWindow.cpp  \
 	 src/CheckNumBox.cpp  \
 	 src/CheckView.cpp  \

--- a/src/CategoryButton.cpp
+++ b/src/CategoryButton.cpp
@@ -1,0 +1,183 @@
+#include "CategoryButton.h"
+#include "Database.h"
+#include "MainWindow.h"
+
+#include <Bitmap.h>
+#include <Catalog.h>
+#include <MenuItem.h>
+#include <Picture.h>
+
+
+#undef B_TRANSLATION_CONTEXT
+#define B_TRANSLATION_CONTEXT "MainWindow"
+
+
+enum {
+	M_SHOW_POPUP,
+	M_CLOSE_POPUP,
+	M_CATEGORY_CHOSEN
+};
+
+
+CategoryButton::CategoryButton(CategoryBox* categorybox)
+	: BButton("calenderbutton", "", new BMessage(M_SHOW_POPUP)),
+	  fCategoryBox(categorybox)
+{
+	float height;
+	fCategoryBox->GetPreferredSize(NULL, &height);
+	BSize size(height - 2, height);
+	SetExplicitSize(size);
+
+	SetIcon(DrawIcon());
+}
+
+
+void
+CategoryButton::AttachedToWindow(void)
+{
+	SetTarget(this);
+}
+
+
+void
+CategoryButton::MessageReceived(BMessage* msg)
+{
+	switch (msg->what) {
+		case M_SHOW_POPUP:
+		{
+			ShowPopUpMenu();
+			break;
+		}
+		case M_CLOSE_POPUP:
+		{
+			fShowingPopUpMenu = false;
+			break;
+		}
+		case M_CATEGORY_CHOSEN:
+		{
+			BString category;
+			msg->FindString("category", &category);
+			fCategoryBox->SetText(category);
+			fCategoryBox->Validate();
+
+			break;
+		}
+		default:
+		{
+			BButton::MessageReceived(msg);
+		}
+	}
+}
+
+
+BBitmap*
+CategoryButton::DrawIcon()
+{
+	font_height fh;
+	GetFontHeight(&fh);
+	float fontHeight = floorf(fh.ascent + fh.descent + fh.leading);
+	BRect rect(0, 0, fontHeight - 2, fontHeight);
+
+	BView* view = new BView(rect, NULL, B_FOLLOW_ALL, B_WILL_DRAW);
+	BBitmap* bitmap = new BBitmap(rect, B_RGBA32, true);
+	bitmap->Lock();
+	bitmap->AddChild(view);
+
+	view->SetDrawingMode(B_OP_COPY);
+	view->SetHighUIColor(B_PANEL_BACKGROUND_COLOR);
+	view->SetLowUIColor(B_PANEL_BACKGROUND_COLOR);
+
+	view->FillRect(rect);
+	view->SetHighUIColor(B_CONTROL_TEXT_COLOR);
+	view->SetPenSize(1.0);
+	view->StrokeRect(rect);
+	view->FillTriangle(rect.LeftBottom(), rect.RightTop(), rect.LeftTop());
+
+	BFont font;
+	view->GetFont(&font);
+	font.SetFace(B_BOLD_FACE);
+	font.SetFlags(B_DISABLE_ANTIALIASING);
+	view->SetFont(&font, B_FONT_FACE | B_FONT_FLAGS);
+
+	view->DrawString("̵",
+		BPoint(
+		ceilf((rect.Width() * 0.75) - view->StringWidth("̵") / 2 - 1),
+		ceilf(rect.Height() * 0.75 + fontHeight / 5)
+		));
+
+	view->SetHighUIColor(B_PANEL_BACKGROUND_COLOR);
+	view->DrawString("+",
+		BPoint(
+		ceilf((rect.Width() / 4) - view->StringWidth("+") / 2 + 1),
+		ceilf(rect.Height() / 5 + fontHeight / 3)
+		));
+
+	view->RemoveSelf();
+	bitmap->Unlock();
+	delete view;
+
+	return bitmap;
+}
+
+
+void
+CategoryButton::ShowPopUpMenu()
+{
+	if (fShowingPopUpMenu)
+		return;
+
+	CategoryPopUp* menu = new CategoryPopUp("PopUpMenu", this);
+	BMenu* incomeMenu = new BMenu(B_TRANSLATE_CONTEXT("Income", "CommonTerms"));
+	BMenu* spendingMenu = new BMenu(B_TRANSLATE_CONTEXT("Spending", "CommonTerms"));
+	BMenuItem* editCategories = new BMenuItem(B_TRANSLATE("Edit categories" B_UTF8_ELLIPSIS),
+		new BMessage(M_SHOW_CATEGORY_WINDOW));
+
+	CppSQLite3Query query = gDatabase.DBQuery(
+		"SELECT * FROM categorylist ORDER BY name ASC", "CategoryView::CategoryView");
+	while (!query.eof()) {
+		int expense = query.getIntField(1);
+		BString name = DeescapeIllegalCharacters(query.getStringField(0));
+
+		BMessage* msg = new BMessage(M_CATEGORY_CHOSEN);
+		msg->AddString("category", name);
+
+		if (expense == SPENDING)
+			spendingMenu->AddItem(new BMenuItem(name, msg));
+		else if (expense == INCOME)
+			incomeMenu->AddItem(new BMenuItem(name, msg));
+
+		query.nextRow();
+	}
+
+	menu->AddItem(incomeMenu);
+	menu->AddItem(spendingMenu);
+	menu->AddItem(new BSeparatorItem());
+	menu->AddItem(editCategories);
+
+	incomeMenu->SetTargetForItems(this);
+	spendingMenu->SetTargetForItems(this);
+	editCategories->SetTarget(Window());
+
+	BPoint where = Bounds().LeftTop();
+	where.x += 10;
+	where.y += 10;
+	ConvertToScreen(&where);
+	menu->Go(where, true, true, true);
+
+	fShowingPopUpMenu = true;
+}
+
+
+CategoryPopUp::CategoryPopUp(const char* name, BMessenger target)
+	:
+	BPopUpMenu(name, false, false),
+	fTarget(target)
+{
+	SetAsyncAutoDestruct(true);
+}
+
+
+CategoryPopUp::~CategoryPopUp()
+{
+	fTarget.SendMessage(M_CLOSE_POPUP);
+}

--- a/src/CategoryButton.h
+++ b/src/CategoryButton.h
@@ -1,0 +1,37 @@
+#ifndef CATEGORYBUTTON_H
+#define CATEGORYBUTTON_H
+
+
+#include <Button.h>
+#include <PopUpMenu.h>
+#include <SupportDefs.h>
+
+#include "CategoryBox.h"
+
+
+class CategoryButton : public BButton {
+public:
+	CategoryButton(CategoryBox* box);
+
+	void AttachedToWindow(void);
+	virtual void MessageReceived(BMessage* message);
+
+private:
+	BBitmap* DrawIcon();
+	void ShowPopUpMenu();
+
+	CategoryBox* fCategoryBox;
+	bool fShowingPopUpMenu;
+};
+
+
+class CategoryPopUp : public BPopUpMenu {
+public:
+					CategoryPopUp(const char* name, BMessenger target);
+	virtual 		~CategoryPopUp();
+
+private:
+	BMessenger 		fTarget;
+};
+
+#endif	// CATEGORYBUTTON_H

--- a/src/CategoryWindow.cpp
+++ b/src/CategoryWindow.cpp
@@ -302,10 +302,10 @@ CategoryView::RefreshCategoryList(void)
 		int expense = query.getIntField(1);
 		BString name = query.getStringField(0);
 
-		if (expense == 0)
+		if (expense == SPENDING)
 			fListView->AddUnder(
 				new CategoryItem(DeescapeIllegalCharacters(name.String())), fSpendingItem);
-		else
+		else if (expense == INCOME)
 			fListView->AddUnder(
 				new CategoryItem(DeescapeIllegalCharacters(name.String())), fIncomeItem);
 
@@ -498,9 +498,9 @@ CategoryRemoveWindow::CategoryRemoveWindow(const char* from, BView* target)
 			continue;
 		}
 
-		if (expense == 0)
+		if (expense == SPENDING)
 			fListView->AddUnder(new CategoryItem(name.String()), fSpendingItem);
-		else
+		else if (expense == INCOME)
 			fListView->AddUnder(new CategoryItem(name.String()), fIncomeItem);
 
 		if (name.CountChars() > maxchars) {

--- a/src/CheckView.cpp
+++ b/src/CheckView.cpp
@@ -10,6 +10,7 @@
 #include "Account.h"
 #include "CalendarButton.h"
 #include "CategoryBox.h"
+#include "CategoryButton.h"
 #include "CheckNumBox.h"
 #include "CheckView.h"
 #include "CurrencyBox.h"
@@ -62,6 +63,8 @@ CheckView::CheckView(const char* name, int32 flags)
 	categoryLabel->SetExplicitSize(BSize(StringWidth("aVeryLongCategoryName"), B_SIZE_UNSET));
 	fCategory = new CategoryBox("categoryentry", "", NULL, new BMessage(M_CATEGORY_CHANGED));
 
+	CategoryButton* categoryButton = new CategoryButton(fCategory);
+
 	BStringView* memoLabel
 		= new BStringView("memolabel", B_TRANSLATE_CONTEXT("Memo", "CommonTerms"));
 	memoLabel->SetExplicitMaxSize(BSize(B_SIZE_UNLIMITED, B_SIZE_UNSET));
@@ -81,30 +84,42 @@ CheckView::CheckView(const char* name, int32 flags)
 	//	#endif
 
 	gDatabase.AddObserver(this);
+
 	// clang-format off
+	BView* calendarWidget = new BView("calendarwidget", B_WILL_DRAW);
+	BLayoutBuilder::Group<>(calendarWidget, B_HORIZONTAL, -2)
+		.Add(fDate)
+		.Add(calendarButton)
+		.End();
+
+	BView* categoryWidget = new BView("categorywidget", B_WILL_DRAW);
+	BLayoutBuilder::Group<>(categoryWidget, B_HORIZONTAL, -2)
+		.Add(fCategory)
+		.Add(categoryButton)
+		.End();
+
 	BLayoutBuilder::Group<>(this, B_VERTICAL, 0)
 		.SetInsets(0)
 		.AddGrid(1.0f, 0.0f)
 			.SetColumnWeight(2, 2.0f)
 			.SetColumnWeight(3, 1.0f)
 			.Add(dateLabel, 0, 0)
-			.Add(fDate, 0, 1)
-			.Add(calendarButton, 1, 1)
-			.Add(typeLabel, 2, 0)
-			.Add(fType, 2, 1)
-			.Add(payeeLabel, 3, 0)
-			.Add(fPayee, 3, 1)
-			.Add(amountLabel, 4, 0)
-			.Add(fAmount, 4, 1)
-			.Add(categoryLabel, 0, 2, 2, 1)
-			.Add(fCategory, 0, 3, 2, 1)
-			.Add(memoLabel, 2, 2, 3)
-			.Add(fMemo, 2, 3, 3)
-			.Add(fEnter, 5, 1, 1, 3)
+			.Add(calendarWidget, 0, 1)
+			.Add(typeLabel, 1, 0)
+			.Add(fType, 1, 1)
+			.Add(payeeLabel, 2, 0)
+			.Add(fPayee, 2, 1)
+			.Add(amountLabel, 3, 0)
+			.Add(fAmount, 3, 1)
+			.Add(categoryLabel, 0, 2)
+			.Add(categoryWidget, 0, 3)
+			.Add(memoLabel, 1, 2, 3)
+			.Add(fMemo, 1, 3, 3)
+			.Add(fEnter, 4, 1, 1, 3)
 			.End()
 		.End();
+	// clang-format on
 }
-// clang-format on
 
 CheckView::~CheckView(void) {}
 

--- a/src/Database.h
+++ b/src/Database.h
@@ -16,6 +16,11 @@ class TransactionType;
 class TransactionData;
 class ScheduledTransData;
 
+enum category_type {
+	SPENDING = 0,
+	INCOME
+};
+
 BString AccountTypeToString(const AccountType& type);
 
 class Database : public Notifier {

--- a/src/ReconcileWindow.cpp
+++ b/src/ReconcileWindow.cpp
@@ -148,16 +148,21 @@ ReconcileWindow::ReconcileWindow(const BRect frame, Account* account)
 	fDate->MakeFocus(true);
 
 	// clang-format off
+	BView* calendarWidget = new BView("calendarwidget", B_WILL_DRAW);
+	BLayoutBuilder::Group<>(calendarWidget, B_HORIZONTAL, -2)
+		.Add(fDate)
+		.Add(calendarButton)
+		.End();
+
 	BLayoutBuilder::Group<>(this, B_VERTICAL)
 		.SetInsets(B_USE_DEFAULT_SPACING)
 		.AddGrid(1.0f, 1.0f)
 			.Add(dateLabel, 0, 0, 2, 1)
-			.Add(fDate, 0, 1)
-			.Add(calendarButton, 1, 1)
-			.Add(openingLabel, 2, 0)
-			.Add(fOpening, 2, 1)
-			.Add(closingLabel, 3, 0)
-			.Add(fClosing, 3, 1)
+			.Add(calendarWidget, 0, 1)
+			.Add(openingLabel, 1, 0)
+			.Add(fOpening, 1, 1)
+			.Add(closingLabel, 2, 0)
+			.Add(fClosing, 2, 1)
 			.End()
 		.AddGrid(1.0f, 1.0f)
 			.Add(chargesLabel, 2, 0)

--- a/src/ReportWindow.cpp
+++ b/src/ReportWindow.cpp
@@ -64,7 +64,7 @@ ReportWindow::ReportWindow(BRect frame)
 	BGroupLayout* subtotalLayout = new BGroupLayout(B_VERTICAL, 0);
 	BGroupLayout* categoriesLayout = new BGroupLayout(B_VERTICAL, 0);
 	BGroupLayout* reportsLayout = new BGroupLayout(B_VERTICAL, 0);
-	BGridLayout* datesLayout = new BGridLayout(1.0f, 1.0f);
+	BGridLayout* datesLayout = new BGridLayout(B_USE_DEFAULT_SPACING, 1.0f);
 
 	BGroupLayout* listLayout = new BGroupLayout(B_VERTICAL, 1.0f);
 
@@ -162,13 +162,19 @@ ReportWindow::ReportWindow(BRect frame)
 	fStartDateBox = new DateBox(
 		"startdate", temp.String(), datestring.String(), new BMessage(M_START_DATE_CHANGED));
 	fStartDateBox->SetDate(GetCurrentYear());
-
-	datesLayout->AddItem(fStartDateBox->CreateLabelLayoutItem(), 0, 0);
-	datesLayout->AddItem(fStartDateBox->CreateTextViewLayoutItem(), 1, 0);
-	fStartDateBox->GetFilter()->SetMessenger(new BMessenger(this));
-
 	CalendarButton* calendarStartButton = new CalendarButton(fStartDateBox);
-	datesLayout->AddView(calendarStartButton, 2, 0);
+
+	// clang-format off
+	BView* calendarStartWidget = new BView("calendarstartwidget", B_WILL_DRAW);
+	BLayoutBuilder::Group<>(calendarStartWidget, B_HORIZONTAL, -2)
+		.Add(fStartDateBox->CreateTextViewLayoutItem())
+		.Add(calendarStartButton)
+		.End();
+	// clang-format on
+
+	datesLayout->AddView(new BStringView("startdate", temp.String()), 0, 0);
+	datesLayout->AddView(calendarStartWidget, 1, 0);
+	fStartDateBox->GetFilter()->SetMessenger(new BMessenger(this));
 
 	gDefaultLocale.DateToString(GetCurrentDate(), datestring);
 	temp = B_TRANSLATE("Ending date:");
@@ -176,12 +182,19 @@ ReportWindow::ReportWindow(BRect frame)
 	fEndDateBox = new DateBox(
 		"enddate", temp.String(), datestring.String(), new BMessage(M_END_DATE_CHANGED));
 	fEndDateBox->SetDate(GetCurrentDate());
-	datesLayout->AddItem(fEndDateBox->CreateLabelLayoutItem(), 0, 1);
-	datesLayout->AddItem(fEndDateBox->CreateTextViewLayoutItem(), 1, 1);
-	fEndDateBox->GetFilter()->SetMessenger(new BMessenger(this));
-
 	CalendarButton* calendarEndButton = new CalendarButton(fEndDateBox);
-	datesLayout->AddView(calendarEndButton, 2, 1);
+
+	// clang-format off
+	BView* calendarEndWidget = new BView("calendarendwidget", B_WILL_DRAW);
+	BLayoutBuilder::Group<>(calendarEndWidget, B_HORIZONTAL, -2)
+		.Add(fEndDateBox->CreateTextViewLayoutItem())
+		.Add(calendarEndButton)
+		.End();
+	// clang-format on
+
+	datesLayout->AddView(new BStringView("enddate", temp.String()), 0, 1);
+	datesLayout->AddView(calendarEndWidget, 1, 1);
+	fEndDateBox->GetFilter()->SetMessenger(new BMessenger(this));
 
 	// TODO: Implement graph support
 	// BBitmap *up, *down;

--- a/src/ScheduleAddWindow.cpp
+++ b/src/ScheduleAddWindow.cpp
@@ -106,8 +106,11 @@ ScheduleAddWindow::ScheduleAddWindow(const BRect& frame, const TransactionData& 
 	BMenuField* intervalfield
 		= new BMenuField("intervalfield", B_TRANSLATE("Frequency:"), fIntervalMenu);
 
+	BStringView* startLabel = new BStringView("startlabel", B_TRANSLATE("Starting date:"));
+	startLabel->SetExplicitMinSize(BSize(be_plain_font->StringWidth(B_TRANSLATE("Starting date:"))
+		+ 10, B_SIZE_UNSET));
 	fStartDate
-		= new DateBox("startdate", B_TRANSLATE("Starting date:"), "", new BMessage(M_DATE_CHANGED));
+		= new DateBox("startdate", NULL, "", new BMessage(M_DATE_CHANGED));
 	fStartDate->UseTabFiltering(false);
 	gDefaultLocale.DateToString(data.Date(), temp);
 	fStartDate->SetText(temp.String());
@@ -140,6 +143,12 @@ ScheduleAddWindow::ScheduleAddWindow(const BRect& frame, const TransactionData& 
 		= new BButton("cancelbutton", B_TRANSLATE("Cancel"), new BMessage(B_QUIT_REQUESTED));
 
 	// clang-format off
+	BView* calendarStartWidget = new BView("calendarstartwidget", B_WILL_DRAW);
+	BLayoutBuilder::Group<>(calendarStartWidget, B_HORIZONTAL, -2)
+		.Add(fStartDate->CreateTextViewLayoutItem())
+		.Add(calendarButton)
+		.End();
+
 	BLayoutBuilder::Group<>(this, B_VERTICAL, 0)
 		.SetInsets(B_USE_WINDOW_SPACING)
 		.AddGrid(1.0f, 0.0f)
@@ -162,10 +171,9 @@ ScheduleAddWindow::ScheduleAddWindow(const BRect& frame, const TransactionData& 
 		.AddGrid(1.0f, B_USE_DEFAULT_SPACING)
 			.SetColumnWeight(1, 2.0f)
 			.Add(intervalfield->CreateLabelLayoutItem(), 0, 0)
-			.Add(intervalfield->CreateMenuBarLayoutItem(), 1, 0, 2)
-			.Add(fStartDate->CreateLabelLayoutItem(), 0, 1)
-			.Add(fStartDate->CreateTextViewLayoutItem(), 1, 1)
-			.Add(calendarButton, 2, 1)
+			.Add(intervalfield->CreateMenuBarLayoutItem(), 1, 0)
+			.Add(startLabel, 0, 1)
+			.Add(calendarStartWidget, 1, 1)
 			.Add(repeatLabel, 0, 2)
 			.Add(dummy, 0, 3)
 			.AddGroup(B_VERTICAL, 1.0f, 1, 2, 1, 2)

--- a/src/SplitView.cpp
+++ b/src/SplitView.cpp
@@ -11,6 +11,7 @@
 #include "Account.h"
 #include "CalendarButton.h"
 #include "CategoryBox.h"
+#include "CalendarButton.h"
 #include "CheckNumBox.h"
 #include "CheckView.h"
 #include "CurrencyBox.h"
@@ -85,6 +86,7 @@ SplitView::SplitView(const char* name, const TransactionData& trans, const int32
 
 	fCategory = new CategoryBox(
 		"categoryentry", "", fTransaction.NameAt(0), new BMessage(M_CATEGORY_CHANGED));
+	fCategoryButton = new CategoryButton(fCategory);
 
 	// Memo
 	BStringView* memoLabel
@@ -125,7 +127,10 @@ SplitView::SplitView(const char* name, const TransactionData& trans, const int32
 	BStringView* splitCategoryLabel
 		= new BStringView("categorylabel", B_TRANSLATE_CONTEXT("Category", "CommonTerms"));
 	splitCategoryLabel->SetExplicitSize(BSize(StringWidth("aVeryLongCategoryName"), B_SIZE_UNSET));
-	fSplitCategory = new BTextControl("splitcategory", NULL, NULL, NULL, B_WILL_DRAW);
+	fSplitCategory = new CategoryBox(
+		"splitcategory", "", fTransaction.NameAt(0), NULL);
+	// fSplitCategory = new BTextControl("splitcategory", NULL, NULL, NULL, B_WILL_DRAW);
+	CategoryButton* splitCategoryButton = new CategoryButton(fSplitCategory);
 
 	// Split amount
 	BStringView* splitAmountLabel
@@ -167,7 +172,25 @@ SplitView::SplitView(const char* name, const TransactionData& trans, const int32
 		fStartExpanded = true;
 	}
 
-	// clang-format off
+// clang-format off
+	BView* calendarWidget = new BView("calendarwidget", B_WILL_DRAW);
+	BLayoutBuilder::Group<>(calendarWidget, B_HORIZONTAL, -2)
+		.Add(fDate)
+		.Add(calendarButton)
+		.End();
+
+	BView* categoryWidget = new BView("categorywidget", B_WILL_DRAW);
+	BLayoutBuilder::Group<>(categoryWidget, B_HORIZONTAL, -2)
+		.Add(fCategory)
+		.Add(fCategoryButton)
+		.End();
+
+	BView* splitCategoryWidget = new BView("splitcategorywidget", B_WILL_DRAW);
+	BLayoutBuilder::Group<>(splitCategoryWidget, B_HORIZONTAL, -2)
+		.Add(fSplitCategory)
+		.Add(splitCategoryButton)
+		.End();
+
 	BLayoutBuilder::Group<>(fSplitContainer, B_VERTICAL, 0)
 		.SetInsets(0)
 		.Add(new BSeparatorView(B_HORIZONTAL, B_PLAIN_BORDER))
@@ -183,7 +206,7 @@ SplitView::SplitView(const char* name, const TransactionData& trans, const int32
 		.AddGrid(1.0f, 0.0f)
 			.SetColumnWeight(2, 2.0f)
 			.Add(splitCategoryLabel, 0, 0)
-			.Add(fSplitCategory, 0, 1)
+			.Add(splitCategoryWidget, 0, 1)
 			.Add(splitAmountLabel, 1, 0)
 			.Add(fSplitAmount, 1, 1)
 			.Add(splitMemoLabel, 2, 0)
@@ -199,18 +222,17 @@ SplitView::SplitView(const char* name, const TransactionData& trans, const int32
 			.SetColumnWeight(2, 2.0f)
 			.SetColumnWeight(3, 1.0f)
 			.Add(dateLabel, 0, 0)
-			.Add(fDate, 0, 1)
-			.Add(calendarButton, 1, 1)
-			.Add(typeLabel, 2, 0)
-			.Add(fType, 2, 1)
-			.Add(payeeLabel, 3, 0)
-			.Add(fPayee, 3, 1)
-			.Add(amountLabel, 4, 0)
-			.Add(fAmount, 4, 1)
-			.Add(categoryLabel, 0, 2, 2, 1)
-			.Add(fCategory, 0, 3, 2, 1)
-			.Add(memoLabel, 2, 2, 3)
-			.Add(fMemo, 2, 3, 3)
+			.Add(calendarWidget, 0, 1)
+			.Add(typeLabel, 1, 0)
+			.Add(fType, 1, 1)
+			.Add(payeeLabel, 2, 0)
+			.Add(fPayee, 2, 1)
+			.Add(amountLabel, 3, 0)
+			.Add(fAmount, 3, 1)
+			.Add(categoryLabel, 0, 2)
+			.Add(categoryWidget, 0, 3)
+			.Add(memoLabel, 1, 2, 3)
+			.Add(fMemo, 1, 3, 3)
 			.End()
 		.AddGroup(B_HORIZONTAL)
 			.Add(fSplit)
@@ -745,6 +767,7 @@ SplitView::ToggleSplit(void)
 
 		fSplitContainer->Show();
 		fCategory->SetEnabled(false);
+		fCategoryButton->SetEnabled(false);
 		if (fCategory->ChildAt(0)->IsFocus())
 			fMemo->MakeFocus();
 	} else {
@@ -752,6 +775,7 @@ SplitView::ToggleSplit(void)
 
 		fSplitContainer->Hide();
 		fCategory->SetEnabled(true);
+		fCategoryButton->SetEnabled(true);
 	}
 }
 

--- a/src/SplitView.h
+++ b/src/SplitView.h
@@ -9,6 +9,8 @@
 #include <StringView.h>
 #include <TextControl.h>
 #include <View.h>
+
+#include "CategoryButton.h"
 #include "Fixed.h"
 #include "Notifier.h"
 #include "TransactionData.h"
@@ -74,6 +76,7 @@ private:
 	PayeeBox* fPayee;
 	CurrencyBox* fAmount;
 	CategoryBox* fCategory;
+	CategoryButton* fCategoryButton;
 	NavTextBox* fMemo;
 	SplitViewFilter* fKeyFilter;
 	BMessenger* fMessenger;
@@ -82,7 +85,8 @@ private:
 	BCheckBox* fSplit;
 
 	BView* fSplitContainer;
-	BTextControl *fSplitCategory, *fSplitAmount, *fSplitMemo;
+	CategoryBox* fSplitCategory;
+	BTextControl *fSplitAmount, *fSplitMemo;
 	BListView* fSplitItems;
 	BScrollView* fSplitScroller;
 	BButton *fAddSplit, *fRemoveSplit;

--- a/src/TransferWindow.cpp
+++ b/src/TransferWindow.cpp
@@ -75,7 +75,10 @@ TransferWindow::InitObject(Account* src, Account* dest, const Fixed& amount)
 	fAmount = new CurrencyBox("amountbox", temp.String(), amt.String(), NULL);
 	fAmount->GetFilter()->SetMessenger(new BMessenger(this));
 
-	fDate = new DateBox("datebox", B_TRANSLATE("Date:"), "", NULL);
+	BStringView* dateLabel = new BStringView("datelabel", B_TRANSLATE("Date:"));
+	dateLabel->SetExplicitMinSize(BSize(be_plain_font->StringWidth(B_TRANSLATE("Date:")) + 10,
+		B_SIZE_UNSET));
+	fDate = new DateBox("datebox", NULL, "", NULL);
 	fDate->GetFilter()->SetMessenger(new BMessenger(this));
 	//	fDate->SetEscapeCancel(true);
 
@@ -127,6 +130,12 @@ TransferWindow::InitObject(Account* src, Account* dest, const Fixed& amount)
 		fDestList->MakeFocus(true);
 
 	// clang-format off
+	BView* calendarWidget = new BView("calendarwidget", B_WILL_DRAW);
+	BLayoutBuilder::Group<>(calendarWidget, B_HORIZONTAL, -2)
+		.Add(fDate)
+		.Add(calendarButton)
+		.End();
+
 	BLayoutBuilder::Group<>(this, B_VERTICAL, B_USE_HALF_ITEM_SPACING)
 		.SetInsets(B_USE_WINDOW_SPACING)
 		.AddGroup(B_HORIZONTAL)
@@ -140,14 +149,13 @@ TransferWindow::InitObject(Account* src, Account* dest, const Fixed& amount)
 				.End()
 			.End()
 		.AddGrid(0.0, B_USE_SMALL_SPACING)
-			.Add(fDate->CreateLabelLayoutItem(), 0, 0)
-			.Add(fDate->CreateTextViewLayoutItem(), 1, 0)
-			.Add(calendarButton, 2, 0)
-			.Add(BSpaceLayoutItem::CreateHorizontalStrut(B_USE_DEFAULT_SPACING), 3, 0)
-			.Add(fAmount->CreateLabelLayoutItem(), 4, 0)
-			.Add(fAmount->CreateTextViewLayoutItem(), 5, 0)
+			.Add(dateLabel, 0, 0)
+			.Add(calendarWidget, 1, 0)
+			.Add(BSpaceLayoutItem::CreateHorizontalStrut(B_USE_DEFAULT_SPACING), 2, 0)
+			.Add(fAmount->CreateLabelLayoutItem(), 3, 0)
+			.Add(fAmount->CreateTextViewLayoutItem(), 4, 0)
 			.Add(fMemo->CreateLabelLayoutItem(), 0, 1)
-			.Add(fMemo->CreateTextViewLayoutItem(), 1, 1, 5, 1)
+			.Add(fMemo->CreateTextViewLayoutItem(), 1, 1, 4, 1)
 			.End()
 		.AddStrut(B_USE_DEFAULT_SPACING)
 		.AddGroup(B_HORIZONTAL)


### PR DESCRIPTION
* Add a button besides the category text box that opens a popup menu showing all categories in "Income" and "Spending" submenus. Choosing a category puts it in the text box. Choosing "Edit categories..." opens the same Categories window also available from the MainWindow.

* Introduce a category_type enum to distinguish SPENDING and INCOME. Test explicitely against those and don't assume INCOME if it's not SPENDING. In future we may have other category types, e.g. TRANSFER which only gets set by CapitalBe, not the user.

* To make the connection between category box and its button a tiny bit more visible "merge" their widgets borders by having a -2 spacing.

* Do the same for the date box + button everywhere. This entails using a separate BStringView for their labels, because putting box and button in one BView with the negative spacing prevents adding the label in the grid layout via CreateLabelLayoutItem(). "The BView already has a parent."