### PR TITLE
Fix split category update

### DIFF
--- a/src/AutoTextControl.cpp
+++ b/src/AutoTextControl.cpp
@@ -199,3 +199,9 @@ AutoTextControlFilter::SetMessenger(BMessenger* msgr)
 		delete fMessenger;
 	fMessenger = msgr;
 }
+
+BMessenger*
+AutoTextControlFilter::GetMessenger()
+{
+	return fMessenger;
+}

--- a/src/AutoTextControl.h
+++ b/src/AutoTextControl.h
@@ -74,6 +74,7 @@ public:
 
 	void SendMessage(BMessage* msg);
 	void SetMessenger(BMessenger* msgr);
+	BMessenger* GetMessenger();
 
 private:
 	AutoTextControl* fBox;

--- a/src/CategoryBox.cpp
+++ b/src/CategoryBox.cpp
@@ -140,7 +140,8 @@ CategoryBox::SetTypeFromCategory(BString category)
 	}
 
 	bool success = true;
-	if (!categoryExists)
+	if (!categoryExists
+		&& category.ICompare(B_TRANSLATE_CONTEXT("Split transaction", "CommonTerms")) != 0)
 		bool success = AddNewCategory(category);
 
 	return success;

--- a/src/CategoryButton.cpp
+++ b/src/CategoryButton.cpp
@@ -1,6 +1,7 @@
 #include "CategoryButton.h"
 #include "Database.h"
 #include "MainWindow.h"
+#include "SplitView.h"
 
 #include <Bitmap.h>
 #include <Catalog.h>
@@ -58,8 +59,13 @@ CategoryButton::MessageReceived(BMessage* msg)
 			BString category;
 			msg->FindString("category", &category);
 			fCategoryBox->SetText(category);
-			fCategoryBox->Validate();
+			bool success = fCategoryBox->Validate();
 
+			if (success) {
+				BMessenger* msgr(fCategoryBox->GetFilter()->GetMessenger());
+				BMessage notice(M_SPLIT_CATEGORY_CHANGED);
+				msgr->SendMessage(&notice);
+			}
 			break;
 		}
 		default:


### PR DESCRIPTION
* Before there was a CategoryButton that would insert a category in the CategoryBox, there was only the CategoryBox' AutoTextControl() that did autocomplete and informed the SplitView that the category was edited.

  The CategoryButton simply inserting the new category in the text control isn't enough. It has to notify the SplitView of that, so it can update a changed category in the the list of split transactions at the bottom of the window.

  After introducing GetMessenger() to the AutoTextControlFilter we can now send a M_SPLIT_CATEGORY_CHANGED to the CategoryBox's parent, i.e. the SplitView.

* Split transactions get the category "Split transaction" by the app. Ignore those when checking against existing user-created categories. It won't be found there and would get added as new user-created category.