### PR TITLE
Fix DB errors with split transactions

### DIFF
--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -375,7 +375,7 @@ Database::RemoveAccount(const int& accountid)
 {
 	LOCK;
 	BString command;
-	command << "SELECT accountid FROM accountlist WHERE accountid = " << accountid << ";";
+	command.SetToFormat("SELECT accountid FROM accountlist WHERE accountid = %i;", accountid);
 	CppSQLite3Query query = DBQuery(command.String(), "Database::RemoveAccount:accountid check");
 
 	if (!query.eof()) {
@@ -388,20 +388,19 @@ Database::RemoveAccount(const int& accountid)
 			Notify(WATCH_DELETE | WATCH_ACCOUNT, &msg);
 		}
 
-		command = "DELETE FROM accountlist WHERE accountid = ";
-		command << accountid << ";";
+		command.SetToFormat("DELETE FROM accountlist WHERE accountid = %i;", accountid);
 		DBCommand(command.String(), "Database::RemoveAccount:delete accountlist item");
 
-		command = "DELETE FROM accountlocale WHERE accountid = ";
-		command << accountid << ";";
+		command.SetToFormat("DELETE FROM accountlocale WHERE accountid = %i;", accountid);
 		DBCommand(command.String(), "Database::RemoveAccount:delete accountlocale item");
 
-		command = "DELETE FROM scheduledlist WHERE accountid = ";
-		command << accountid << ";";
+		command.SetToFormat("DELETE FROM scheduledlist WHERE accountid = %i;", accountid);
 		DBCommand(command.String(), "Database::RemoveAccount:delete scheduled items");
 
-		command = "DROP TABLE account_";
-		command << accountid;
+		command.SetToFormat("DELETE FROM transactionlist WHERE accountid = %i;", accountid);
+		DBCommand(command.String(), "Database::RemoveAccount:delete transactionlist items");
+
+		command.SetToFormat("DROP TABLE account_%i;", accountid);
 		DBCommand(command.String(), "Database::RemoveAccount:drop account table");
 
 		fList.RemoveItem(item);

--- a/src/SplitViewFilter.cpp
+++ b/src/SplitViewFilter.cpp
@@ -3,11 +3,9 @@
 #include <Catalog.h>
 #include <TextControl.h>
 #include "Account.h"
-#include "AutoTextControl.h"
 #include "CategoryBox.h"
 #include "Database.h"
 #include "MsgDefs.h"
-#include "TimeSupport.h"
 
 
 #undef B_TRANSLATION_CONTEXT

--- a/src/TransactionItem.cpp
+++ b/src/TransactionItem.cpp
@@ -25,7 +25,7 @@ TransactionItem::TransactionItem(const TransactionData& trans)
 	  fPayee(trans.Payee()),
 	  fAmount(trans.Amount()),
 	  fCategory(""),
-	  fMemo(trans.Memo()),
+	  fMemo(trans.MemoAt(0)),
 	  fStatus(trans.Status()),
 	  fID(trans.GetID()),
 	  fTimeStamp(trans.GetTimeStamp())
@@ -241,7 +241,7 @@ TransactionItem::SetData(const TransactionData& trans)
 		fCategory = B_TRANSLATE_CONTEXT("Split", "CommonTerms");
 	else
 		fCategory = trans.NameAt(0);
-	fMemo = trans.Memo();
+	fMemo = trans.MemoAt(0);
 	fStatus = trans.Status();
 	fID = trans.GetID();
 }


### PR DESCRIPTION
* When editing a split transaction, the original transaction is deleted from the database, and new transactions are created for each split item with the same transaction ID. The ID wasn't correctly set, causing the original transaction to be deleted, and the new transactions to be added to the  transaction with ID 0.
* Deleting an account would not remove associated transactions from the `transactionlist` table.
* Converted some queries to use BString::SetToFormat