### PR TITLE
Don't let the user set internal categories

### DIFF
--- a/src/CategoryBox.cpp
+++ b/src/CategoryBox.cpp
@@ -56,7 +56,7 @@ CategoryBoxFilter::KeyFilter(const int32& key, const int32& mod)
 
 		BString autocomplete = acc->AutocompleteCategory(string.String());
 
-		if (autocomplete.CountChars() > 0) {
+		if (autocomplete.CountChars() > 0 && !IsInternalCategory(autocomplete.String())) {
 			BMessage automsg(M_CATEGORY_AUTOCOMPLETE);
 			automsg.AddInt32("start", strlen(TextControl()->Text()) + 1);
 			automsg.AddString("string", autocomplete.String());
@@ -101,11 +101,7 @@ CategoryBox::Validate(void)
 			return false;
 	}
 
-	if (category.ICompare(B_TRANSLATE_CONTEXT("Income", "CommonTerms")) == 0
-		|| category.ICompare(B_TRANSLATE_CONTEXT("Spending", "CommonTerms")) == 0
-		|| category.ICompare(B_TRANSLATE_CONTEXT("Split", "CommonTerms")) == 0
-		|| category.ICompare(B_TRANSLATE_CONTEXT("Transfer", "CommonTerms")) == 0
-		|| category.ICompare(B_TRANSLATE_CONTEXT("Uncategorized", "CommonTerms")) == 0) {
+	if (IsInternalCategory(category.String())) {
 		ShowAlert(B_TRANSLATE("Can't use this category name"),
 			B_TRANSLATE(
 				"CapitalBe uses 'Income', 'Spending', 'Split', 'Transfer', and 'Uncategorized' "

--- a/src/CategoryButton.cpp
+++ b/src/CategoryButton.cpp
@@ -137,7 +137,10 @@ CategoryButton::ShowPopUpMenu()
 	while (!query.eof()) {
 		int expense = query.getIntField(1);
 		BString name = DeescapeIllegalCharacters(query.getStringField(0));
-
+		if (IsInternalCategory(name.String())) {
+			query.nextRow();
+			continue;
+		}
 		BMessage* msg = new BMessage(M_CATEGORY_CHOSEN);
 		msg->AddString("category", name);
 

--- a/src/CategoryWindow.cpp
+++ b/src/CategoryWindow.cpp
@@ -214,11 +214,7 @@ CategoryView::MessageReceived(BMessage* msg)
 				|| msg->FindBool("expense", &expense) != B_OK)
 				break;
 
-			if (name.ICompare(B_TRANSLATE_CONTEXT("Income", "CommonTerms")) == 0
-				|| name.ICompare(B_TRANSLATE_CONTEXT("Spending", "CommonTerms")) == 0
-				|| name.ICompare(B_TRANSLATE_CONTEXT("Split", "CommonTerms")) == 0
-				|| name.ICompare(B_TRANSLATE_CONTEXT("Transfer", "CommonTerms")) == 0
-				|| name.ICompare(B_TRANSLATE_CONTEXT("Uncategorized", "CommonTerms")) == 0) {
+			if (IsInternalCategory(name.String())) {
 				ShowAlert(B_TRANSLATE("Can't use this category name"),
 					B_TRANSLATE(
 						"CapitalBe uses 'Income', 'Spending', 'Split', 'Transfer', and "
@@ -303,9 +299,13 @@ CategoryView::RefreshCategoryList(void)
 	CppSQLite3Query query = gDatabase.DBQuery(
 		"SELECT * FROM categorylist ORDER BY name DESC", "CategoryView::CategoryView");
 	while (!query.eof()) {
-		int expense = query.getIntField(1);
 		BString name = query.getStringField(0);
+		if (IsInternalCategory(name.String())) {
+			query.nextRow();
+			continue;
+		}
 
+		int expense = query.getIntField(1);
 		if (expense == SPENDING)
 			fListView->AddUnder(new CategoryItem(name.String()), fSpendingItem);
 		else if (expense == INCOME)

--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -1,4 +1,5 @@
 #include "Database.h"
+#include <Catalog.h>
 #include <Directory.h>
 #include <Entry.h>
 #include <stdio.h>
@@ -1603,4 +1604,23 @@ Database::DeescapeDatabase(void)
 	}
 
 	return B_OK;
+}
+
+bool
+IsInternalCategory(const char* category)
+{
+	const char* internal_categories[] = {
+		B_TRANSLATE_CONTEXT("Income", "CommonTerms"),
+		B_TRANSLATE_CONTEXT("Spending", "CommonTerms"),
+		B_TRANSLATE_CONTEXT("Split", "CommonTerms"),
+		B_TRANSLATE_CONTEXT("Transfer", "CommonTerms"),
+		B_TRANSLATE_CONTEXT("Uncategorized", "CommonTerms"),
+		NULL
+	};
+
+	for (int32 i = 0; internal_categories[i] != NULL; i++) {
+		if (strcasecmp(internal_categories[i], category) == 0)
+		return true;
+	}
+	return false;
 }

--- a/src/Database.h
+++ b/src/Database.h
@@ -4,6 +4,7 @@
 #include <Locker.h>
 #include <String.h>
 #include <time.h>
+
 #include "Account.h"
 #include "CBLocale.h"
 #include "CppSQLite3.h"
@@ -22,6 +23,7 @@ enum category_type {
 };
 
 BString AccountTypeToString(const AccountType& type);
+bool IsInternalCategory(const char* category);
 
 class Database : public Notifier {
 public:

--- a/src/SplitView.cpp
+++ b/src/SplitView.cpp
@@ -167,7 +167,7 @@ SplitView::SplitView(const char* name, const TransactionData& trans, const int32
 
 	if (fTransaction.CountCategories() > 1
 		|| strcmp(fTransaction.NameAt(0), B_TRANSLATE_CONTEXT("Split", "CommonTerms")) == 0) {
-		fCategory->SetText(B_TRANSLATE("Split transaction"));
+		fCategory->SetText(B_TRANSLATE_CONTEXT("Split transaction", "CommonTerms"));
 		fStartExpanded = true;
 	}
 


### PR DESCRIPTION
The user mustn't set "internal categories" (Income, Spending, Split, Transfer, Uncategorized). Therefore they mustn't show up in the "Categories" window, or the menu of the category button, or when doing autocomplete.

The new function IsInternalCategory() checks if a category is "internal".