### PR TITLE
Bug fixes for split transactions

### DIFF
--- a/locales/en.catkeys
+++ b/locales/en.catkeys
@@ -1,4 +1,4 @@
-1	English	application/x-vnd.wgp-CapitalBe	3544348528
+1	English	application/x-vnd.wgp-CapitalBe	575229969
 Year	ReportWindow		Year
 None	ReportWindow		None
 Export to QIF file…	MainWindow		Export to QIF file…
@@ -20,7 +20,6 @@ You need to enter the date for the statement to 'Quick balance'.	ReconcileWindow
 Cancel	ScheduleAddWindow		Cancel
 Account total	MainWindow		Account total
 CapitalBe	System name		CapitalBe
-Total: %sum%	SplitView		Total: %sum%
 Import from QIF file…	MainWindow		Import from QIF file…
 Preview:	PrefWindow		Preview:
 Ending date:	ReportWindow		Ending date:
@@ -55,21 +54,23 @@ Decimals:	PrefWindow		Decimals:
 CapitalBe didn't understand the amount for 'Bank charges'	ReconcileWindow		CapitalBe didn't understand the amount for 'Bank charges'
 You need to enter a check number or transaction type, such as ATM (for debit card transactions and the like), DEP (for deposits), or your own code for some other kind of expense.	CheckView		You need to enter a check number or transaction type, such as ATM (for debit card transactions and the like), DEP (for deposits), or your own code for some other kind of expense.
 Balance	RegisterView		Balance
-Uncategorized	SplitView		Uncategorized
 Date	CommonTerms		Date
 Frequency	ScheduleListWindow		Frequency
 CapitalBe understands lots of different ways of entering dates. Apparently, this wasn't one of them. You'll need to change how you entered this date. Sorry.	TextInput		CapitalBe understands lots of different ways of entering dates. Apparently, this wasn't one of them. You'll need to change how you entered this date. Sorry.
 Settings	PrefWindow		Settings
 Cancel	ReconcileWindow		Cancel
+Spending	CategoryWindow		Spending
 Reconcile…	MainWindow		Reconcile…
 Spending	BudgetWindow		Spending
+Do you really want to add this transaction without a category?\n\nEven then, you need to select a transaction type, 'income' or 'spending'.\n	CategoryWindow		Do you really want to add this transaction without a category?\n\nEven then, you need to select a transaction type, 'income' or 'spending'.\n
+Uncategorized	CommonTerms		Uncategorized
+Transfer	CommonTerms		Transfer
 Reopen	MainWindow		Reopen
 Edit…	CategoryWindow		Edit…
 Annually	ScheduleAddWindow		Annually
 Close	MainWindow		Close
 Split	CommonTerms		Split
 Import	MainWindow		Import
-<Uncategorized>	Import		<Uncategorized>
 Interest earned	ReconcileWindow		Interest earned
 Quit	Locale		Quit
 Once deleted, you will not be able to get back any data on this account.	MainWindow		Once deleted, you will not be able to get back any data on this account.
@@ -81,12 +82,12 @@ Total deposits: %s	ReconcileWindow		Total deposits: %s
 Memo	CommonTerms		Memo
 Selected:	PrefWindow		Selected:
 Save bugreport	Locale		Save bugreport
-Type	CommonTerms		Type
 Indefinitely	ScheduleAddWindow		Indefinitely
+Type	CommonTerms		Type
 Cancel	MainWindow		Cancel
 <No accounts>	MainWindow		<No accounts>
-There may be a typo or the wrong kind of currency symbol for this account.	TextInput		There may be a typo or the wrong kind of currency symbol for this account.
 Repeat:	ScheduleAddWindow		Repeat:
+There may be a typo or the wrong kind of currency symbol for this account.	TextInput		There may be a typo or the wrong kind of currency symbol for this account.
 Appears before amount	PrefWindow		Appears before amount
 Unreconciled total: %s	ReconcileWindow		Unreconciled total: %s
 Couldn't Quick balance	ReconcileWindow		Couldn't Quick balance
@@ -112,6 +113,7 @@ Transactions	TransactionReport		Transactions
 Spending	CommonTerms		Spending
 CapitalBe didn't understand the amount	TextInput		CapitalBe didn't understand the amount
 Average	BudgetWindow		Average
+New category	CategoryWindow		New category
 Summary	BudgetWindow		Summary
 You need to enter a payee.	TextInput		You need to enter a payee.
 Ending balance	ReconcileWindow		Ending balance
@@ -119,7 +121,6 @@ Accounts:	ReportWindow		Accounts:
 Help: Main window	MainWindow		Help: Main window
 Cancel	Account		Cancel
 Reconcile	ReconcileWindow		Reconcile
-CapitalBe uses the words 'Income', 'Spending', and 'Split' for managing categories, so you can't use them as category names. Please choose a different name for your new category.	CategoryWindow		CapitalBe uses the words 'Income', 'Spending', and 'Split' for managing categories, so you can't use them as category names. Please choose a different name for your new category.
 Weekly	ScheduleListWindow		Weekly
 Please choose a new category for all transactions currently in the '%%CATEGORY_NAME%%' category.	CategoryWindow		Please choose a new category for all transactions currently in the '%%CATEGORY_NAME%%' category.
 Reset	ReconcileWindow		Reset
@@ -128,10 +129,8 @@ The split total must match the amount box	SplitView		The split total must match 
 About CapitalBe	MainWindow		About CapitalBe
 No memo	ScheduledTransItem		No memo
 Can't use this category name	CategoryWindow		Can't use this category name
-Do you want to add this transaction without a category?	CategoryWindow		Do you want to add this transaction without a category?
 Budget	BudgetWindow		Budget
 Monthly	BudgetWindow		Monthly
-Edit categories…	MainWindow		Edit categories…
 OK	TransferWindow		OK
 Total worth	NetWorthReport		Total worth
 times	ScheduleAddWindow		times
@@ -167,10 +166,9 @@ Total checks:	ReconcileWindow		Total checks:
 Remove item	SplitView		Remove item
 Transaction	MainWindow		Transaction
 Edit transfer	TransferWindow		Edit transfer
-Reports	MainWindow		Reports
 Categories	CategoryWindow		Categories
+Reports	MainWindow		Reports
 Account	MainWindow		Account
-Uncategorized	CategoryWindow		Uncategorized
 Unselected:	PrefWindow		Unselected:
 {0, plural,one{This account has # scheduled transaction that will be removed.}other{This account has # scheduled transactions that will be removed.}}	MainWindow		{0, plural,one{This account has # scheduled transaction that will be removed.}other{This account has # scheduled transactions that will be removed.}}
 Total deposits:	ReconcileWindow		Total deposits:
@@ -182,6 +180,7 @@ Credit card account	Import		Credit card account
 If you intend to transfer money, it will need to be an amount that is not zero.	TransferWindow		If you intend to transfer money, it will need to be an amount that is not zero.
 You can schedule transfers, deposits, or ATM transactions.	MainWindow		You can schedule transfers, deposits, or ATM transactions.
 Success!	ReconcileWindow		Success!
+Income	CategoryWindow		Income
 Edit category	CategoryWindow		Edit category
 This account is closed, and the settings cannot be edited. Please reopen the account if you need to make changes.	MainWindow		This account is closed, and the settings cannot be edited. Please reopen the account if you need to make changes.
 QuickTracker	RegisterView		QuickTracker
@@ -189,10 +188,10 @@ Schedule transaction	ScheduleAddWindow		Schedule transaction
 Next payment	ScheduleListWindow		Next payment
 New name:	CategoryWindow		New name:
 Help: Reconcile	ReconcileWindow		Help: Reconcile
+Edit categories…	CategoryButton		Edit categories…
 Bank charge	ReconcileWindow		Bank charge
 Budget	MainWindow		Budget
 OK	ScheduleAddWindow		OK
-Add	CategoryWindow		Add
 Quit	MainWindow		Quit
 Lowest	BudgetWindow		Lowest
 Previous	MainWindow		Previous
@@ -211,6 +210,7 @@ Not enough accounts for a transfer	MainWindow		Not enough accounts for a transfe
 Delete…	MainWindow		Delete…
 CapitalBe has run into a bug. This shouldn't happen, but it has.\nWould you like to:\n\n1) Save the bug to a text file for uploading to\nCapitalBe's issue tracker (https://github.com/HaikuArchives/CapitalBe/issues)\n\n2) Just quit and do nothing\n	Locale		CapitalBe has run into a bug. This shouldn't happen, but it has.\nWould you like to:\n\n1) Save the bug to a text file for uploading to\nCapitalBe's issue tracker (https://github.com/HaikuArchives/CapitalBe/issues)\n\n2) Just quit and do nothing\n
 New account	Account		New account
+You created the new category '%categoryname%'.\n\nPlease select a transaction type for it, 'income' or 'spending'.	CategoryWindow		You created the new category '%categoryname%'.\n\nPlease select a transaction type for it, 'income' or 'spending'.
 Scheduled transactions	ScheduleListWindow		Scheduled transactions
 Agh! Bug!	Locale		Agh! Bug!
 Starting date:	ReportWindow		Starting date:
@@ -230,9 +230,9 @@ You need to have an account created in order to reconcile it.	MainWindow		You ne
 Payee is missing	TextInput		Payee is missing
 CapitalBe didn't understand the date you entered	TextInput		CapitalBe didn't understand the date you entered
 Recalculate all	BudgetWindow		Recalculate all
-Split transaction	SplitView		Split transaction
 Total checks: %s	ReconcileWindow		Total checks: %s
 Quarterly	BudgetWindow		Quarterly
+CapitalBe uses 'Income', 'Spending', 'Split', 'Transfer', and 'Uncategorized' for managing accounts, so you can't use them as category names.\n\nPlease choose a different name for your new category.	CategoryWindow		CapitalBe uses 'Income', 'Spending', 'Split', 'Transfer', and 'Uncategorized' for managing accounts, so you can't use them as category names.\n\nPlease choose a different name for your new category.
 Remove category	CategoryWindow		Remove category
 You cannot schedule transactions on a closed account.	MainWindow		You cannot schedule transactions on a closed account.
 CapitalBe didn't understand the amount for 'Interest earned'	ReconcileWindow		CapitalBe didn't understand the amount for 'Interest earned'

--- a/locales/en.catkeys
+++ b/locales/en.catkeys
@@ -1,4 +1,4 @@
-1	English	application/x-vnd.wgp-CapitalBe	575229969
+1	English	application/x-vnd.wgp-CapitalBe	3280201285
 Year	ReportWindow		Year
 None	ReportWindow		None
 Export to QIF file…	MainWindow		Export to QIF file…
@@ -52,7 +52,6 @@ Monthly	ScheduleListWindow		Monthly
 Frequency	BudgetWindow		Frequency
 Decimals:	PrefWindow		Decimals:
 CapitalBe didn't understand the amount for 'Bank charges'	ReconcileWindow		CapitalBe didn't understand the amount for 'Bank charges'
-You need to enter a check number or transaction type, such as ATM (for debit card transactions and the like), DEP (for deposits), or your own code for some other kind of expense.	CheckView		You need to enter a check number or transaction type, such as ATM (for debit card transactions and the like), DEP (for deposits), or your own code for some other kind of expense.
 Balance	RegisterView		Balance
 Date	CommonTerms		Date
 Frequency	ScheduleListWindow		Frequency
@@ -69,7 +68,6 @@ Reopen	MainWindow		Reopen
 Edit…	CategoryWindow		Edit…
 Annually	ScheduleAddWindow		Annually
 Close	MainWindow		Close
-Split	CommonTerms		Split
 Import	MainWindow		Import
 Interest earned	ReconcileWindow		Interest earned
 Quit	Locale		Quit
@@ -83,11 +81,10 @@ Memo	CommonTerms		Memo
 Selected:	PrefWindow		Selected:
 Save bugreport	Locale		Save bugreport
 Indefinitely	ScheduleAddWindow		Indefinitely
-Type	CommonTerms		Type
 Cancel	MainWindow		Cancel
 <No accounts>	MainWindow		<No accounts>
-Repeat:	ScheduleAddWindow		Repeat:
 There may be a typo or the wrong kind of currency symbol for this account.	TextInput		There may be a typo or the wrong kind of currency symbol for this account.
+Repeat:	ScheduleAddWindow		Repeat:
 Appears before amount	PrefWindow		Appears before amount
 Unreconciled total: %s	ReconcileWindow		Unreconciled total: %s
 Couldn't Quick balance	ReconcileWindow		Couldn't Quick balance
@@ -166,8 +163,8 @@ Total checks:	ReconcileWindow		Total checks:
 Remove item	SplitView		Remove item
 Transaction	MainWindow		Transaction
 Edit transfer	TransferWindow		Edit transfer
-Categories	CategoryWindow		Categories
 Reports	MainWindow		Reports
+Categories	CategoryWindow		Categories
 Account	MainWindow		Account
 Unselected:	PrefWindow		Unselected:
 {0, plural,one{This account has # scheduled transaction that will be removed.}other{This account has # scheduled transactions that will be removed.}}	MainWindow		{0, plural,one{This account has # scheduled transaction that will be removed.}other{This account has # scheduled transactions that will be removed.}}
@@ -195,7 +192,7 @@ OK	ScheduleAddWindow		OK
 Quit	MainWindow		Quit
 Lowest	BudgetWindow		Lowest
 Previous	MainWindow		Previous
-Transaction type is missing	CheckView		Transaction type is missing
+Type	TransactionReport	Type of transaction, spending or income	Type
 Accounts	RegisterView		Accounts
 Amount	ScheduleAddWindow		Amount
 Income	CommonTerms		Income
@@ -225,6 +222,7 @@ Date:	TransferWindow		Date:
 To account:	TransferWindow		To account:
 Add account transfer	TransferWindow		Add account transfer
 Amount	CommonTerms		Amount
+Split	CommonTerms	The noun 'split', as in 'a split-category'	Split
 Quick balance failed. This doesn't mean that you did something wrong - it's just that 'Quick balance' works on simpler cases in balancing an account than this one. Sorry.	ReconcileWindow		Quick balance failed. This doesn't mean that you did something wrong - it's just that 'Quick balance' works on simpler cases in balancing an account than this one. Sorry.
 You need to have an account created in order to reconcile it.	MainWindow		You need to have an account created in order to reconcile it.
 Payee is missing	TextInput		Payee is missing

--- a/src/Account.cpp
+++ b/src/Account.cpp
@@ -1,6 +1,5 @@
 #include "Account.h"
 #include <Catalog.h>
-#include <ctype.h>
 #include <stdlib.h>
 #include "Database.h"
 
@@ -122,12 +121,6 @@ Account::AutocompleteCategory(const char* input)
 	if (!input)
 		return BString();
 
-	// TODO: Add language support here
-	if (toupper(input[0]) == (int)'S') {
-		int32 inputlength = strlen(input);
-		if (strncasecmp(input, B_TRANSLATE_CONTEXT("Split", "CommonTerms"), inputlength) == 0)
-			return B_TRANSLATE_CONTEXT("Split", "CommonTerms");
-	}
 	CppSQLite3Buffer bufSQL;
 	BString searchString;
 	searchString << input << "%";

--- a/src/Account.cpp
+++ b/src/Account.cpp
@@ -1,4 +1,5 @@
 #include "Account.h"
+#include <Catalog.h>
 #include <ctype.h>
 #include <stdlib.h>
 #include "Database.h"
@@ -124,8 +125,8 @@ Account::AutocompleteCategory(const char* input)
 	// TODO: Add language support here
 	if (toupper(input[0]) == (int)'S') {
 		int32 inputlength = strlen(input);
-		if (strncasecmp(input, "Split", inputlength) == 0)
-			return "Split";
+		if (strncasecmp(input, B_TRANSLATE_CONTEXT("Split", "CommonTerms"), inputlength) == 0)
+			return B_TRANSLATE_CONTEXT("Split", "CommonTerms");
 	}
 	CppSQLite3Buffer bufSQL;
 	BString searchString;

--- a/src/CategoryBox.cpp
+++ b/src/CategoryBox.cpp
@@ -137,8 +137,11 @@ CategoryBox::SetTypeFromCategory(BString category)
 
 	bool success = true;
 	if (!categoryExists
-		&& category.ICompare(B_TRANSLATE_CONTEXT("Split", "CommonTerms")) != 0)
+		&& category.ICompare(B_TRANSLATE_ALL("Split", "CommonTerms",
+			   "The noun 'split', as in 'a split-category'"))
+			!= 0) {
 		bool success = AddNewCategory(category);
+	}
 
 	return success;
 }

--- a/src/CategoryBox.cpp
+++ b/src/CategoryBox.cpp
@@ -137,7 +137,7 @@ CategoryBox::SetTypeFromCategory(BString category)
 
 	bool success = true;
 	if (!categoryExists
-		&& category.ICompare(B_TRANSLATE_CONTEXT("Split transaction", "CommonTerms")) != 0)
+		&& category.ICompare(B_TRANSLATE_CONTEXT("Split", "CommonTerms")) != 0)
 		bool success = AddNewCategory(category);
 
 	return success;

--- a/src/CheckView.cpp
+++ b/src/CheckView.cpp
@@ -343,7 +343,7 @@ CheckView::DoNextField(void)
 	} else if (fCategory->ChildAt(0)->IsFocus()) {
 		// TODO: don't force entering a transaction when going to the
 		// split window via key editing
-		if (strcmp(fCategory->Text(), "Split") == 0) {
+		if (strcmp(fCategory->Text(), B_TRANSLATE_CONTEXT("Split", "CommonTerms")) == 0) {
 			Window()->PostMessage(M_ENTER_TRANSACTION, this);
 			Window()->PostMessage(M_EDIT_TRANSACTION);
 			return;

--- a/src/CheckView.cpp
+++ b/src/CheckView.cpp
@@ -343,7 +343,10 @@ CheckView::DoNextField(void)
 	} else if (fCategory->ChildAt(0)->IsFocus()) {
 		// TODO: don't force entering a transaction when going to the
 		// split window via key editing
-		if (strcmp(fCategory->Text(), B_TRANSLATE_CONTEXT("Split", "CommonTerms")) == 0) {
+		if (strcmp(fCategory->Text(),
+				B_TRANSLATE_ALL("Split", "CommonTerms",
+					"The noun 'split', as in 'a split-category'"))
+			== 0) {
 			Window()->PostMessage(M_ENTER_TRANSACTION, this);
 			Window()->PostMessage(M_EDIT_TRANSACTION);
 			return;

--- a/src/CheckView.cpp
+++ b/src/CheckView.cpp
@@ -341,17 +341,6 @@ CheckView::DoNextField(void)
 		if (fAmount->Validate(false))
 			fCategory->MakeFocus(true);
 	} else if (fCategory->ChildAt(0)->IsFocus()) {
-		// TODO: don't force entering a transaction when going to the
-		// split window via key editing
-		if (strcmp(fCategory->Text(),
-				B_TRANSLATE_ALL("Split", "CommonTerms",
-					"The noun 'split', as in 'a split-category'"))
-			== 0) {
-			Window()->PostMessage(M_ENTER_TRANSACTION, this);
-			Window()->PostMessage(M_EDIT_TRANSACTION);
-			return;
-		}
-
 		fMemo->MakeFocus(true);
 	} else if (fMemo->ChildAt(0)->IsFocus()) {
 		fEnter->MakeFocus(true);

--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -1159,8 +1159,11 @@ Database::AddCategory(const char* name, const bool& isexpense)
 	if (!name || HasCategory(name))
 		return;
 
-	if (strcasecmp(name, B_TRANSLATE_CONTEXT("Split", "CommonTerms")) == 0)
+	if (strcasecmp(name,
+			B_TRANSLATE_ALL("Split", "CommonTerms", "The noun 'split', as in 'a split-category'"))
+		== 0) {
 		return;
+	}
 
 	CppSQLite3Buffer bufSQL;
 	bufSQL.format("INSERT INTO categorylist VALUES(%Q, %i)", name, (isexpense ? 0 : 1));
@@ -1601,7 +1604,8 @@ bool
 IsInternalCategory(const char* category)
 {
 	const char* internal_categories[] = {B_TRANSLATE_CONTEXT("Income", "CommonTerms"),
-		B_TRANSLATE_CONTEXT("Spending", "CommonTerms"), B_TRANSLATE_CONTEXT("Split", "CommonTerms"),
+		B_TRANSLATE_CONTEXT("Spending", "CommonTerms"),
+		B_TRANSLATE_ALL("Split", "CommonTerms", "The noun 'split', as in 'a split-category'"),
 		B_TRANSLATE_CONTEXT("Transfer", "CommonTerms"),
 		B_TRANSLATE_CONTEXT("Uncategorized", "CommonTerms"), NULL};
 

--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -1159,7 +1159,7 @@ Database::AddCategory(const char* name, const bool& isexpense)
 	if (!name || HasCategory(name))
 		return;
 
-	if (strcasecmp(name, "split") == 0)
+	if (strcasecmp(name, B_TRANSLATE_CONTEXT("Split", "CommonTerms")) == 0)
 		return;
 
 	CppSQLite3Buffer bufSQL;

--- a/src/ScheduleAddWindow.cpp
+++ b/src/ScheduleAddWindow.cpp
@@ -71,7 +71,8 @@ ScheduleAddWindow::ScheduleAddWindow(const BRect& frame, const TransactionData& 
 		BSize(be_plain_font->StringWidth("aLongCategoryName"), B_SIZE_UNSET));
 	BString label;
 	if (data.CountCategories() > 1)
-		label << B_TRANSLATE_CONTEXT("Split", "CommonTerms");
+		label << B_TRANSLATE_ALL("Split", "CommonTerms",
+			"The noun 'split', as in 'a split-category'");
 	else
 		label << data.NameAt(0);
 	BTextControl* category = new BTextControl("category", NULL, label.String(), NULL);

--- a/src/ScheduledTransItem.cpp
+++ b/src/ScheduledTransItem.cpp
@@ -33,7 +33,8 @@ ScheduledTransItem::ScheduledTransItem(const ScheduledTransData& data)
 	gDefaultLocale.DateToString(data.Date(), fDate);
 
 	if (data.CountCategories() > 1)
-		fCategory = B_TRANSLATE_CONTEXT("Split", "CommonTerms");
+		fCategory
+			= B_TRANSLATE_ALL("Split", "CommonTerms", "The noun 'split', as in 'a split-category'");
 	else
 		fCategory = data.NameAt(0);
 }
@@ -201,7 +202,8 @@ ScheduledTransItem::SetData(const TransactionData& trans)
 	fPayee = trans.Payee();
 	locale.CurrencyToString(trans.Amount().AbsoluteValue(), fAmount);
 	if (trans.CountCategories() > 1)
-		fCategory = B_TRANSLATE_CONTEXT("Split", "CommonTerms");
+		fCategory
+			= B_TRANSLATE_ALL("Split", "CommonTerms", "The noun 'split', as in 'a split-category'");
 	else
 		fCategory = trans.NameAt(0);
 	fMemo = trans.Memo();

--- a/src/SplitView.cpp
+++ b/src/SplitView.cpp
@@ -11,7 +11,6 @@
 #include "Account.h"
 #include "CalendarButton.h"
 #include "CategoryBox.h"
-#include "CheckNumBox.h"
 #include "CheckView.h"
 #include "CurrencyBox.h"
 #include "DAlert.h"
@@ -162,7 +161,7 @@ SplitView::SplitView(const char* name, const TransactionData& trans, const int32
 
 	if (fTransaction.CountCategories() > 1
 		|| strcmp(fTransaction.NameAt(0), B_TRANSLATE_CONTEXT("Split", "CommonTerms")) == 0) {
-		fCategory->SetText(B_TRANSLATE_CONTEXT("Split transaction", "CommonTerms"));
+		fCategory->SetText(B_TRANSLATE_CONTEXT("Split", "CommonTerms"));
 		fStartExpanded = true;
 	}
 
@@ -325,8 +324,9 @@ SplitView::MessageReceived(BMessage* msg)
 			if (!fAmount->Validate())
 				break;
 
-			if (!fCategory->Validate())
-				break;
+			if (fSplitContainer->IsHidden())
+				if (!fCategory->Validate())
+					break;
 
 			if (!ValidateSplitItems())
 				break;
@@ -740,8 +740,9 @@ SplitView::ValidateAllFields(void)
 	if (!fPayee->Validate())
 		return false;
 
-	if (!fCategory->Validate())
-		return false;
+	if (fSplitContainer->IsHidden())
+		if (!fCategory->Validate())
+			return false;
 
 	if (!fAmount->Validate())
 		return false;
@@ -760,7 +761,7 @@ SplitView::ToggleSplit(void)
 
 		fSplitContainer->Show();
 		fCategory->SetEnabled(false);
-		fCategory->SetText(B_TRANSLATE("Split transaction"));
+		fCategory->SetText(B_TRANSLATE_CONTEXT("Split", "CommonTerms"));
 		fCategoryButton->SetEnabled(false);
 		fMemo->SetEnabled(false);
 		if (fCategory->ChildAt(0)->IsFocus())
@@ -770,6 +771,7 @@ SplitView::ToggleSplit(void)
 
 		fSplitContainer->Hide();
 		fCategory->SetEnabled(true);
+		fCategory->SetText(fTransaction.NameAt(0));
 		fCategoryButton->SetEnabled(true);
 		fMemo->SetEnabled(true);
 	}

--- a/src/SplitView.cpp
+++ b/src/SplitView.cpp
@@ -160,8 +160,12 @@ SplitView::SplitView(const char* name, const TransactionData& trans, const int32
 	}
 
 	if (fTransaction.CountCategories() > 1
-		|| strcmp(fTransaction.NameAt(0), B_TRANSLATE_CONTEXT("Split", "CommonTerms")) == 0) {
-		fCategory->SetText(B_TRANSLATE_CONTEXT("Split", "CommonTerms"));
+		|| strcmp(fTransaction.NameAt(0),
+			   B_TRANSLATE_ALL("Split", "CommonTerms",
+				   "The noun 'split', as in 'a split-category'"))
+			== 0) {
+		fCategory->SetText(
+			B_TRANSLATE_ALL("Split", "CommonTerms", "The noun 'split', as in 'a split-category'"));
 		fStartExpanded = true;
 	}
 
@@ -761,7 +765,8 @@ SplitView::ToggleSplit(void)
 
 		fSplitContainer->Show();
 		fCategory->SetEnabled(false);
-		fCategory->SetText(B_TRANSLATE_CONTEXT("Split", "CommonTerms"));
+		fCategory->SetText(
+			B_TRANSLATE_ALL("Split", "CommonTerms", "The noun 'split', as in 'a split-category'"));
 		fCategoryButton->SetEnabled(false);
 		fMemo->SetEnabled(false);
 		if (fCategory->ChildAt(0)->IsFocus())

--- a/src/SplitViewFilter.cpp
+++ b/src/SplitViewFilter.cpp
@@ -191,7 +191,9 @@ SplitViewFilter::Filter(BMessage* msg, BHandler** target)
 			BString autocomplete = acc->AutocompleteCategory(string.String());
 
 			if (autocomplete.CountChars() > 0
-				&& autocomplete != B_TRANSLATE_CONTEXT("Split", "CommonTerms")) {
+				&& autocomplete
+					!= B_TRANSLATE_ALL("Split", "CommonTerms",
+						"The noun 'split', as in 'a split-category'")) {
 				BMessage automsg(M_CATEGORY_AUTOCOMPLETE);
 				automsg.AddInt32("start", strlen(text->Text()) + 1);
 				automsg.AddString("string", autocomplete.String());

--- a/src/TransactionItem.cpp
+++ b/src/TransactionItem.cpp
@@ -31,7 +31,8 @@ TransactionItem::TransactionItem(const TransactionData& trans)
 	  fTimeStamp(trans.GetTimeStamp())
 {
 	if (trans.CountCategories() > 1)
-		fCategory = B_TRANSLATE_CONTEXT("Split", "CommonTerms");
+		fCategory
+			= B_TRANSLATE_ALL("Split", "CommonTerms", "The noun 'split', as in 'a split-category'");
 	else
 		fCategory = trans.NameAt(0);
 }
@@ -229,7 +230,8 @@ TransactionItem::SetData(const TransactionData& trans)
 	fPayee = trans.Payee();
 	fAmount = trans.Amount();
 	if (trans.CountCategories() > 1)
-		fCategory = B_TRANSLATE_CONTEXT("Split", "CommonTerms");
+		fCategory
+			= B_TRANSLATE_ALL("Split", "CommonTerms", "The noun 'split', as in 'a split-category'");
 	else
 		fCategory = trans.NameAt(0);
 	fMemo = trans.MemoAt(0);


### PR DESCRIPTION
* Replace "Split transaction" with "Split"
* Restore orginal category when un-splitting
* Update catkeys
* Don't validate 'Split' category for split transactions
* Remove 'Split' as shortcut when entering new transaction