### PR TITLE
Increase memo and payee character limit

### DIFF
--- a/src/CheckView.cpp
+++ b/src/CheckView.cpp
@@ -46,6 +46,7 @@ CheckView::CheckView(const char* name, int32 flags)
 		= new BStringView("payeelabel", B_TRANSLATE_CONTEXT("Payee", "CommonTerms"));
 	payeeLabel->SetExplicitMaxSize(BSize(B_SIZE_UNLIMITED, B_SIZE_UNSET));
 	fPayee = new PayeeBox("payeeentry", "", NULL, new BMessage(M_PAYEE_CHANGED));
+	fPayee->SetCharacterLimit(63);
 
 	BStringView* amountLabel
 		= new BStringView("amountlabel", B_TRANSLATE_CONTEXT("Amount", "CommonTerms"));
@@ -64,7 +65,7 @@ CheckView::CheckView(const char* name, int32 flags)
 	memoLabel->SetExplicitMaxSize(BSize(B_SIZE_UNLIMITED, B_SIZE_UNSET));
 	fMemo = new NavTextBox("memoentry", "", NULL, new BMessage(M_MEMO_CHANGED));
 	fMemo->TextView()->DisallowChar(B_ESCAPE);
-	fMemo->SetCharacterLimit(21);
+	fMemo->SetCharacterLimit(63);
 
 	fEnter = new BButton("enterbutton", B_TRANSLATE("Enter"), new BMessage(M_ENTER_TRANSACTION));
 	fEnter->SetExplicitMaxSize(BSize(B_SIZE_UNSET, B_SIZE_UNLIMITED));


### PR DESCRIPTION
Fixes issue #103 . The database fields are set to VARCHAR(63), but AFAIK, SQLite does not enforce this, and any length is possible.

I've set the limit to 63 characters, mostly because very long strings will look strange and/or break the layout. Maybe there's a good way to handle long strings, like adding a tool tip on hover or something like that?