### PR TITLE
Fix auto-complete for Payee and Category

### DIFF
--- a/src/CategoryBox.cpp
+++ b/src/CategoryBox.cpp
@@ -48,20 +48,19 @@ CategoryBoxFilter::KeyFilter(const int32& key, const int32& mod)
 	TextControl()->TextView()->GetSelection(&start, &end);
 	if (end == (int32)strlen(TextControl()->Text())) {
 		TextControl()->TextView()->Delete(start, end);
+		BString string = "";
+		GetCurrentMessage()->FindString("bytes", &string);
 
-		BString string;
-		if (GetCurrentMessage()->FindString("bytes", &string) != B_OK)
-			string = "";
 		string.Prepend(TextControl()->Text());
 
 		BString autocomplete = acc->AutocompleteCategory(string.String());
+		if (autocomplete.CountChars() == 0 || IsInternalCategory(autocomplete.String()))
+			autocomplete = string;
 
-		if (autocomplete.CountChars() > 0 && !IsInternalCategory(autocomplete.String())) {
-			BMessage automsg(M_CATEGORY_AUTOCOMPLETE);
-			automsg.AddInt32("start", strlen(TextControl()->Text()) + 1);
-			automsg.AddString("string", autocomplete.String());
-			SendMessage(&automsg);
-		}
+		BMessage automsg(M_CATEGORY_AUTOCOMPLETE);
+		automsg.AddInt32("start", strlen(TextControl()->Text()) + 1);
+		automsg.AddString("string", autocomplete.String());
+		SendMessage(&automsg);
 	}
 
 	return B_DISPATCH_MESSAGE;

--- a/src/PayeeBox.cpp
+++ b/src/PayeeBox.cpp
@@ -50,20 +50,19 @@ PayeeBoxFilter::KeyFilter(const int32& key, const int32& mod)
 	TextControl()->TextView()->GetSelection(&start, &end);
 	if (end == (int32)strlen(TextControl()->Text())) {
 		TextControl()->TextView()->Delete(start, end);
+		BString string = "";
+		GetCurrentMessage()->FindString("bytes", &string);
 
-		BString string;
-		if (GetCurrentMessage()->FindString("bytes", &string) != B_OK)
-			string = "";
 		string.Prepend(TextControl()->Text());
 
 		BString autocomplete = acc->AutocompletePayee(string.String());
+		if (autocomplete.CountChars() == 0)
+			autocomplete = string;
 
-		if (autocomplete.CountChars() > 0) {
-			BMessage automsg(M_PAYEE_AUTOCOMPLETE);
-			automsg.AddInt32("start", strlen(TextControl()->Text()) + 1);
-			automsg.AddString("string", autocomplete.String());
-			SendMessage(&automsg);
-		}
+		BMessage automsg(M_PAYEE_AUTOCOMPLETE);
+		automsg.AddInt32("start", strlen(TextControl()->Text()) + 1);
+		automsg.AddString("string", autocomplete.String());
+		SendMessage(&automsg);
 	}
 
 	return B_DISPATCH_MESSAGE;


### PR DESCRIPTION
If the user enters a letter that has the Autocomplete*() function return empty, because the string doesn't match anymore, send the M_*_AUTOCOMPLETE BMessage with the entire text control text. Including that non-matching letter.